### PR TITLE
refactor: bi-monthly sweep — merge duplicate constants, shared model base, hoist role dicts

### DIFF
--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -167,6 +167,22 @@ TIMESTAMPED_REPORT_GLOBS = (
     "failure-*.json",
 )
 
+FAMILY_STRONG_ROLES: Dict[str, set] = {
+    "docker": {"vmnetd", "backend", "backend_service", "virtualization", "sandbox", "docker_helper"},
+    "claude": {"claude_app", "vscode_cli"},
+    "codex": {"codex_app", "helper", "renderer", "cli_service"},
+}
+FAMILY_WEAK_ROLES: Dict[str, set] = {
+    "docker": {"docker_cli", "docker_cli_probe", "shell_docker_probe", "shell_docker_session"},
+    "claude": {"shipit", "crashpad"},
+    "codex": {"updater", "crashpad"},
+}
+FAMILY_PRIMARY_ROLES: Dict[str, set] = {
+    "docker": {"vmnetd", "backend", "virtualization"},
+    "claude": {"claude_app", "vscode_cli"},
+    "codex": {"codex_app", "cli_service"},
+}
+
 
 def now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -625,21 +641,9 @@ def summarize_family(
     active_primary_pids: List[int] = []
     roles = set()
 
-    strong_roles = {
-        "docker": {"vmnetd", "backend", "backend_service", "virtualization", "sandbox", "docker_helper"},
-        "claude": {"claude_app", "vscode_cli"},
-        "codex": {"codex_app", "helper", "renderer", "cli_service"},
-    }[family]
-    weak_roles = {
-        "docker": {"docker_cli", "docker_cli_probe", "shell_docker_probe", "shell_docker_session"},
-        "claude": {"shipit", "crashpad"},
-        "codex": {"updater", "crashpad"},
-    }[family]
-    primary_roles = {
-        "docker": {"vmnetd", "backend", "virtualization"},
-        "claude": {"claude_app", "vscode_cli"},
-        "codex": {"codex_app", "cli_service"},
-    }[family]
+    strong_roles = FAMILY_STRONG_ROLES[family]
+    weak_roles = FAMILY_WEAK_ROLES[family]
+    primary_roles = FAMILY_PRIMARY_ROLES[family]
 
     for record in processes:
         if record.family != family:

--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -48,14 +48,7 @@ CLAUDE_LIBRARY_CACHE_BASENAMES = [
 ]
 CODEX_LIBRARY_CACHE_BASENAMES = ["com.openai.codex"]
 
-CLAUDE_SUPPORT_CACHE_DIRS = [
-    "Cache",
-    "Code Cache",
-    "GPUCache",
-    "DawnGraphiteCache",
-    "DawnWebGPUCache",
-]
-CODEX_SUPPORT_CACHE_DIRS = [
+SUPPORT_CACHE_DIRS = [
     "Cache",
     "Code Cache",
     "GPUCache",
@@ -886,13 +879,13 @@ def gather_storage_records(family_summaries: Dict[str, Dict[str, Any]]) -> Tuple
             classification = "PROTECTED_STATE" if basename in family_summaries.get(family, {}).get("protected_library_caches", []) else "SAFE_CACHE"
             add_record(f"library_cache:{basename}", path, family, classification, "Protected if the owning app family is active.")
 
-    for dirname in CLAUDE_SUPPORT_CACHE_DIRS:
+    for dirname in SUPPORT_CACHE_DIRS:
         path = PROTECTED_STATE_PATHS["claude_support"] / dirname
         if path.exists():
             classification = "SAFE_CACHE" if family_summaries["claude"]["state"] in {"inactive", "residual_data_only"} else "PROTECTED_STATE"
             add_record(f"claude_support_cache:{dirname}", path, "claude", classification, "Claude support cache directory.")
 
-    for dirname in CODEX_SUPPORT_CACHE_DIRS:
+    for dirname in SUPPORT_CACHE_DIRS:
         path = PROTECTED_STATE_PATHS["codex_support"] / dirname
         if path.exists():
             classification = "SAFE_CACHE" if family_summaries["codex"]["state"] == "inactive" else "PROTECTED_STATE"
@@ -1129,11 +1122,11 @@ def plan_cleanup(snapshot: Dict[str, Any], mode: str = "balanced") -> List[Clean
         claude_state = process_summary["claude"]["state"]
         codex_state = process_summary["codex"]["state"]
         if claude_state in {"inactive", "residual_data_only"}:
-            for dirname in CLAUDE_SUPPORT_CACHE_DIRS:
+            for dirname in SUPPORT_CACHE_DIRS:
                 path = PROTECTED_STATE_PATHS["claude_support"] / dirname
                 safe_delete_action(f"claude_support_cache:{dirname}", path, "claude", "Claude support cache while inactive.")
         if codex_state == "inactive":
-            for dirname in CODEX_SUPPORT_CACHE_DIRS:
+            for dirname in SUPPORT_CACHE_DIRS:
                 path = PROTECTED_STATE_PATHS["codex_support"] / dirname
                 safe_delete_action(f"codex_support_cache:{dirname}", path, "codex", "Codex support cache while inactive.")
 

--- a/dreamcleanr/models.py
+++ b/dreamcleanr/models.py
@@ -5,7 +5,13 @@ from typing import Any, Dict, List, Optional
 
 
 @dataclass
-class ProcessRecord:
+class _Dictable:
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ProcessRecord(_Dictable):
     pid: int
     ppid: int
     etime: str
@@ -20,12 +26,9 @@ class ProcessRecord:
     classification: str = "UNCLASSIFIED"
     reasons: List[str] = field(default_factory=list)
 
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
-
 
 @dataclass
-class StorageRecord:
+class StorageRecord(_Dictable):
     label: str
     path: str
     family: str
@@ -33,12 +36,9 @@ class StorageRecord:
     size_bytes: int
     notes: str
 
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
-
 
 @dataclass
-class CleanupAction:
+class CleanupAction(_Dictable):
     target: str
     target_type: str
     family: str
@@ -48,12 +48,9 @@ class CleanupAction:
     reason: str
     details: Dict[str, Any] = field(default_factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
-
 
 @dataclass
-class DockerInventory:
+class DockerInventory(_Dictable):
     engine_available: bool
     engine_state: str = "unknown"
     info: Optional[Dict[str, Any]] = None
@@ -65,12 +62,9 @@ class DockerInventory:
     timed_out_commands: List[str] = field(default_factory=list)
     raw_text: Dict[str, str] = field(default_factory=dict)
 
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
-
 
 @dataclass
-class DetectorFinding:
+class DetectorFinding(_Dictable):
     key: str
     title: str
     status: str
@@ -83,24 +77,18 @@ class DetectorFinding:
     active_project_roots: List[str] = field(default_factory=list)
     observed_paths: List[Dict[str, Any]] = field(default_factory=list)
 
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
-
 
 @dataclass
-class ProjectSignal:
+class ProjectSignal(_Dictable):
     root: str
     toolchains: List[str]
     markers: List[str]
     source_process_count: int
     families: List[str]
 
-    def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
-
 
 @dataclass
-class ScanSnapshot:
+class ScanSnapshot(_Dictable):
     run_id: str
     started_at: str
     finished_at: str
@@ -115,10 +103,6 @@ class ScanSnapshot:
     project_signals: List[ProjectSignal]
     protected_items: List[StorageRecord]
     manual_review_items: List[StorageRecord]
-
-    def to_dict(self) -> Dict[str, Any]:
-        payload = asdict(self)
-        return payload
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Behavior-preserving refactor sweep. Three focused commits, no feature changes, no bug fixes.

**Tests before:** 31 pass  
**Tests after:** 31 pass  
**Time spent:** ~20 minutes

---

### Commit 1 — `refactor: merge identical CLAUDE/CODEX_SUPPORT_CACHE_DIRS constants`

`CLAUDE_SUPPORT_CACHE_DIRS` and `CODEX_SUPPORT_CACHE_DIRS` in `core.py` were byte-for-byte identical five-element lists. Keeping them as two separate names is a silent footgun: any future change to one list (e.g. a new Electron cache subdir) would need to be applied twice, and a missed update would cause the Claude and Codex cleanup paths to silently diverge.

Merged into a single `SUPPORT_CACHE_DIRS`. The four call-sites each continue to iterate the same names while passing the correct family-specific parent paths and label prefixes.

**Files:** `dreamcleanr/core.py`

---

### Commit 2 — `refactor: lift repeated to_dict into shared _Dictable base class`

Six dataclasses in `models.py` each had an identical two-line `to_dict` method:

```python
def to_dict(self) -> Dict[str, Any]:
    return asdict(self)
```

Any new model added to this file would need to copy the same boilerplate, and a future change to the serialisation strategy (e.g. adding an envelope key) would require six hunts. Introducing a no-field `_Dictable` base provides the default once; subclasses become pure field declarations.

`ScanSnapshot`'s no-op intermediate variable (`payload = asdict(self); return payload`) was cleaned up in the same pass. `CleanupReport`, which has a genuinely custom `to_dict`, is unchanged.

**Files:** `dreamcleanr/models.py`

---

### Commit 3 — `refactor: hoist inline role-set dicts to module-level constants`

`summarize_family()` rebuilt three `{family: frozenset}` dicts on every call solely to do a single `[family]` key-lookup. This buried role membership inside a runtime function rather than alongside the other module-level configuration, and made it easy to accidentally edit the wrong dict when adding a new role.

Promoted to `FAMILY_STRONG_ROLES`, `FAMILY_WEAK_ROLES`, `FAMILY_PRIMARY_ROLES` at module scope. `summarize_family` is reduced to three one-line lookups.

**Files:** `dreamcleanr/core.py`

---

## Items considered but skipped

| Item | Reason skipped |
|------|---------------|
| Action-policy cascade in `summarize_family` (8 if/elif branches) | Two branches compute values from runtime state (`active_primary_pids`, `paths_present`), so the cascade can't be made purely data-driven without adding conditional logic inside the lookup structure — net complexity increase. |
| `classify_process_role` inner role-assignment chains | Each branch checks multiple `"token" in args` conditions with AND/OR combinations; a tuple-predicate list would be less readable than the explicit if/elif. |
| `family_rows` / `why_safe` loop duplication in `reporting.py` | The loops look similar but read from different data sources (`family_summaries` vs `snapshot["process_summary"]`); unifying them would couple two logically distinct data paths. |
| New-module test coverage (priority 5) | No new `.py` modules were added in the last 2 weeks — `git log --oneline --since='2 weeks ago' -- 'dreamcleanr/'` returns nothing. |

---
_Generated by [Claude Code](https://claude.ai/code/session_016ngoEeYkFQgMA2yPJZ8nWE)_