### PR TITLE
refactor: bi-monthly sweep — cache-dir alias, tuple-driven classification, module-level role sets

### DIFF
--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -777,6 +777,49 @@ def summarize_family(
     }
 
 
+# Each entry: (predicate(record, has_active_parent, state, stale_signal), classification, reason).
+# reason may be a plain string or a callable with the same four-argument signature.
+# Walked in order; first match wins. Forgetting to wire a new case → only the fallback changes,
+# not a silent mis-classification into an existing bucket.
+_CLASSIFICATION_RULES: List[Tuple[Any, str, Any]] = [
+    (
+        lambda r, ap, st, ss: r.role in {"vmnetd", "backend", "virtualization", "claude_app", "vscode_cli", "codex_app", "cli_service"},
+        "ACTIVE_PRIMARY",
+        "primary runtime role",
+    ),
+    (
+        lambda r, ap, st, ss: ap and st == "active",
+        "ACTIVE_HELPER",
+        "active parent chain",
+    ),
+    (
+        lambda r, ap, st, ss: r.role in {"docker_cli_probe", "shell_docker_probe"} and ss,
+        "STALE_CLI",
+        "old docker probe chain with low activity",
+    ),
+    (
+        lambda r, ap, st, ss: r.role in {"updater", "shipit", "crashpad"} and not ap,
+        "BACKGROUND_ONLY",
+        "background updater or crash handler without active root",
+    ),
+    (
+        lambda r, ap, st, ss: r.role in {"helper", "renderer", "docker_helper", "sandbox", "backend_service"} and not ap and ss,
+        "STALE_HELPER",
+        "helper without active root and low activity",
+    ),
+    (
+        lambda r, ap, st, ss: r.role in {"docker_cli", "shell_docker_session"},
+        "BACKGROUND_ONLY",
+        "interactive or non-probe docker CLI preserved conservatively",
+    ),
+    (
+        lambda r, ap, st, ss: st in {"background_only", "cli_only"},
+        "BACKGROUND_ONLY",
+        lambda r, ap, st, ss: f"{r.family} state is {st}",
+    ),
+]
+
+
 def classify_processes(processes: List[ProcessRecord], family_summaries: Dict[str, Dict[str, Any]]) -> None:
     by_pid = {process.pid: process for process in processes}
     active_primary_pids = {
@@ -786,10 +829,7 @@ def classify_processes(processes: List[ProcessRecord], family_summaries: Dict[st
 
     for record in processes:
         if record.family in {"self", "other"}:
-            if record.family == "self":
-                record.classification = "IGNORED"
-            else:
-                record.classification = "OTHER"
+            record.classification = "IGNORED" if record.family == "self" else "OTHER"
             continue
 
         family = record.family
@@ -802,27 +842,13 @@ def classify_processes(processes: List[ProcessRecord], family_summaries: Dict[st
             and record.cpu_percent <= STALE_PROCESS_MAX_CPU_PERCENT
         )
 
-        if record.role in {"vmnetd", "backend", "virtualization", "claude_app", "vscode_cli", "codex_app", "cli_service"}:
-            record.classification = "ACTIVE_PRIMARY"
-            record.reasons.append("primary runtime role")
-        elif has_active_parent and state == "active":
-            record.classification = "ACTIVE_HELPER"
-            record.reasons.append("active parent chain")
-        elif record.role in {"docker_cli_probe", "shell_docker_probe"} and stale_signal:
-            record.classification = "STALE_CLI"
-            record.reasons.append("old docker probe chain with low activity")
-        elif record.role in {"updater", "shipit", "crashpad"} and not has_active_parent:
-            record.classification = "BACKGROUND_ONLY"
-            record.reasons.append("background updater or crash handler without active root")
-        elif record.role in {"helper", "renderer", "docker_helper", "sandbox", "backend_service"} and not has_active_parent and stale_signal:
-            record.classification = "STALE_HELPER"
-            record.reasons.append("helper without active root and low activity")
-        elif record.role in {"docker_cli", "shell_docker_session"}:
-            record.classification = "BACKGROUND_ONLY"
-            record.reasons.append("interactive or non-probe docker CLI preserved conservatively")
-        elif state in {"background_only", "cli_only"}:
-            record.classification = "BACKGROUND_ONLY"
-            record.reasons.append(f"{family} state is {state}")
+        for pred, cls, reason in _CLASSIFICATION_RULES:
+            if pred(record, has_active_parent, state, stale_signal):
+                record.classification = cls
+                record.reasons.append(
+                    reason(record, has_active_parent, state, stale_signal) if callable(reason) else reason
+                )
+                break
         else:
             record.classification = "ACTIVE_HELPER"
             record.reasons.append("conservative protection fallback")

--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -614,6 +614,25 @@ def ancestor_chain(pid: int, by_pid: Dict[int, ProcessRecord]) -> List[ProcessRe
     return chain
 
 
+_STRONG_ROLES: Dict[str, frozenset] = {
+    "docker": frozenset({"vmnetd", "backend", "backend_service", "virtualization", "sandbox", "docker_helper"}),
+    "claude": frozenset({"claude_app", "vscode_cli"}),
+    "codex": frozenset({"codex_app", "helper", "renderer", "cli_service"}),
+}
+_WEAK_ROLES: Dict[str, frozenset] = {
+    "docker": frozenset({"docker_cli", "docker_cli_probe", "shell_docker_probe", "shell_docker_session"}),
+    "claude": frozenset({"shipit", "crashpad"}),
+    "codex": frozenset({"updater", "crashpad"}),
+}
+_PRIMARY_ROLES: Dict[str, frozenset] = {
+    "docker": frozenset({"vmnetd", "backend", "virtualization"}),
+    "claude": frozenset({"claude_app", "vscode_cli"}),
+    "codex": frozenset({"codex_app", "cli_service"}),
+}
+# Flat union used by classify_processes; derived from _PRIMARY_ROLES so both stay in sync.
+_PRIMARY_ROLES_FLAT: frozenset = frozenset().union(*_PRIMARY_ROLES.values())
+
+
 def summarize_family(
     family: str,
     processes: List[ProcessRecord],
@@ -627,21 +646,9 @@ def summarize_family(
     active_primary_pids: List[int] = []
     roles = set()
 
-    strong_roles = {
-        "docker": {"vmnetd", "backend", "backend_service", "virtualization", "sandbox", "docker_helper"},
-        "claude": {"claude_app", "vscode_cli"},
-        "codex": {"codex_app", "helper", "renderer", "cli_service"},
-    }[family]
-    weak_roles = {
-        "docker": {"docker_cli", "docker_cli_probe", "shell_docker_probe", "shell_docker_session"},
-        "claude": {"shipit", "crashpad"},
-        "codex": {"updater", "crashpad"},
-    }[family]
-    primary_roles = {
-        "docker": {"vmnetd", "backend", "virtualization"},
-        "claude": {"claude_app", "vscode_cli"},
-        "codex": {"codex_app", "cli_service"},
-    }[family]
+    strong_roles = _STRONG_ROLES[family]
+    weak_roles = _WEAK_ROLES[family]
+    primary_roles = _PRIMARY_ROLES[family]
 
     for record in processes:
         if record.family != family:
@@ -783,7 +790,7 @@ def summarize_family(
 # not a silent mis-classification into an existing bucket.
 _CLASSIFICATION_RULES: List[Tuple[Any, str, Any]] = [
     (
-        lambda r, ap, st, ss: r.role in {"vmnetd", "backend", "virtualization", "claude_app", "vscode_cli", "codex_app", "cli_service"},
+        lambda r, ap, st, ss: r.role in _PRIMARY_ROLES_FLAT,
         "ACTIVE_PRIMARY",
         "primary runtime role",
     ),

--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -55,13 +55,8 @@ CLAUDE_SUPPORT_CACHE_DIRS = [
     "DawnGraphiteCache",
     "DawnWebGPUCache",
 ]
-CODEX_SUPPORT_CACHE_DIRS = [
-    "Cache",
-    "Code Cache",
-    "GPUCache",
-    "DawnGraphiteCache",
-    "DawnWebGPUCache",
-]
+# Both app families share the same Chromium/Electron cache directory layout.
+CODEX_SUPPORT_CACHE_DIRS = CLAUDE_SUPPORT_CACHE_DIRS
 
 
 def detector_registry(home: Optional[Path] = None) -> Dict[str, Dict[str, Any]]:


### PR DESCRIPTION
## Summary

Behavior-preserving refactor sweep. Three focused commits, all 31 tests green before and after each one.

---

### Commit 1 — `alias CODEX_SUPPORT_CACHE_DIRS to CLAUDE_SUPPORT_CACHE_DIRS`

**Why:** `CLAUDE_SUPPORT_CACHE_DIRS` and `CODEX_SUPPORT_CACHE_DIRS` were identical 5-entry list literals (Cache, Code Cache, GPUCache, DawnGraphiteCache, DawnWebGPUCache). Both apps share Chromium/Electron's cache layout, but two separate definitions mean any future addition to one silently skips the other — a divergence that would only show up as a missed cleanup pass at runtime.

**Change:** Remove the `CODEX_SUPPORT_CACHE_DIRS` literal; alias it to `CLAUDE_SUPPORT_CACHE_DIRS`. One edit propagates to both families.

---

### Commit 2 — `convert classify_processes if/elif cascade to tuple-driven rules`

**Why:** `classify_processes` had a 7-branch `if/elif` chain that assigned `record.classification`. The footgun: adding a new process role without wiring a branch silently routes it to `ACTIVE_HELPER` via the `else` fallback — no error, wrong classification. Reviewers must read every branch to spot a missing case.

**Change:** Extract `_CLASSIFICATION_RULES`, a module-level list of `(predicate, classification, reason)` tuples walked in order. Adding a classification is now one tuple entry. The `for/else` fallback is the only "unmatched" path, making omissions visible during review. The single dynamic reason (family-state string) uses a callable entry so the pattern stays uniform.

---

### Commit 3 — `lift summarize_family role sets to module-level constants`

**Why:** `summarize_family` rebuilt three `{family: set()}` dicts (`strong_roles`, `weak_roles`, `primary_roles`) on every call. Worse, `classify_processes` duplicated the union of primary roles as a hardcoded set literal — so promoting a role to "primary" in `summarize_family` would silently leave `classify_processes` classifying it wrong.

**Change:** `_STRONG_ROLES`, `_WEAK_ROLES`, `_PRIMARY_ROLES` become module constants. `_PRIMARY_ROLES_FLAT` (derived from `_PRIMARY_ROLES`) is the single source used by the first rule in `_CLASSIFICATION_RULES`, keeping both functions in sync automatically.

---

## Stats

| | |
|---|---|
| Tests before | 31 |
| Tests after | 31 |
| Files changed | 1 (`dreamcleanr/core.py`) |

## Items considered but skipped

- **`_launchctl_status` uses `os.system` instead of `subprocess.run`** — would be a clean improvement, but the function has no test coverage; skipped per the behavior-preservation constraint.
- **Silent `except Exception: request_id = None` in `mcp_server.py`** — these two inner try/except blocks are legitimately guarding against `NameError` on an unbound `message` variable. Adding `log.exception` would require a file-handler logger (stderr would contaminate the MCP protocol wire format); deferred as infrastructure work.
- **`summarize_family` policy if/elif (lines ~730–765)** — 7 branches setting `allowed_actions`/`blocked_actions`/`reason`. Some branches have dynamic values (docker active `reason` varies on `active_primary_pids`; claude inactive conditionally appends `prune_vm`), making a clean table approach require post-table fixups. Left as a candidate for a deeper refactor with a dedicated helper function.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B56RxYU1fBLdry4EfL9o8c)_