### PR TITLE
ci: migrate Ubuntu jobs to self-hosted runner on getupsoft

### DIFF
--- a/.github/workflows/business-review.yml
+++ b/.github/workflows/business-review.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, getupsoft]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, getupsoft]
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]

--- a/.github/workflows/governance-review.yml
+++ b/.github/workflows/governance-review.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   governance:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, getupsoft]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   asset-install:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, getupsoft]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -69,7 +69,7 @@ jobs:
           PY
 
   public-install-script:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, getupsoft]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -104,7 +104,7 @@ jobs:
           PY
 
   upgrade-path:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, getupsoft]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -157,7 +157,7 @@ jobs:
           test "$(python -c 'from importlib.metadata import version; print(version("dreamcleanr"))')" = "${{ steps.releases.outputs.latest_version }}"
 
   public-surface:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, getupsoft]
     timeout-minutes: 10
     steps:
       - name: Verify public site and latest release

--- a/.github/workflows/ops-health.yml
+++ b/.github/workflows/ops-health.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   health:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, getupsoft]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pages-verify.yml
+++ b/.github/workflows/pages-verify.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   verify:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, getupsoft]
     timeout-minutes: 10
     steps:
       - name: Verify public Pages deployment

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, getupsoft]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, getupsoft]
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Frees DreamCleanr's Linux CI from GitHub-hosted minutes; runs on getupsoft (`getupsoft-dreamcleanr` runner, online + verified).

`runs-on: ubuntu-latest` → `runs-on: [self-hosted, linux, x64, getupsoft]` across 7 workflows. macOS jobs untouched.

Closes the DreamCleanr arm of the billing-resilience plan (see jonlynchfinancial#1 for full context).