### PR TITLE
Memory-first reclaim + re-tiered safety, faster scans, Trash net, smart caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ env:
 
 jobs:
   test:
+    # Public repo on a self-hosted runner: never execute untrusted fork-PR code on getupsoft
+    # (it shares the box with production containers + a business partner). Same-repo PRs and
+    # pushes still run.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, linux, x64, getupsoft]
     strategy:
       matrix:

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -1,0 +1,25 @@
+name: Release (native macOS)
+
+# SCAFFOLD — dormant until the native menu-bar app is ready. Runs ONLY on an
+# on-demand self-hosted macOS runner (your Mac), since Apple's build/codesign/
+# notarize toolchain cannot run on the Linux getupsoft runner. Manual trigger only.
+on:
+  workflow_dispatch:
+
+jobs:
+  build-native:
+    runs-on: [self-hosted, macOS, arm64, native-build]
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build SwiftUI menu-bar package
+        run: |
+          cd macos/DreamCleanrMenubar
+          swift build -c release
+      # TODO (when shipping a notarized .app):
+      #   - codesign with Developer ID Application
+      #   - xcrun notarytool submit --wait
+      #   - xcrun stapler staple
+      #   - attach the signed/notarized artifact to the GitHub Release
+      - name: Note
+        run: echo "Native build compiled. Codesign + notarize steps are TODO before public release."

--- a/.github/workflows/release-native.yml
+++ b/.github/workflows/release-native.yml
@@ -6,6 +6,11 @@ name: Release (native macOS)
 on:
   workflow_dispatch:
 
+# Least-privilege per CodeQL on PR #30. This workflow only reads source +
+# builds; no write needs.
+permissions:
+  contents: read
+
 jobs:
   build-native:
     runs-on: [self-hosted, macOS, arm64, native-build]

--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ everything lower tiers do, plus a wider blast radius.
 | `balanced` (default) | Regenerable dev caches (uv, npm, npx, Gradle, trunk), Docker prune, stale-process trim | Yes |
 | `max` (aggressive) | Everything in `balanced` **plus** the broad `~/Library/Caches` sweep and inactive Claude/Codex support caches | Yes |
 
-`--apply` is a no-op without confirmation: an interactive run prompts `[y/N]`,
-and a non-interactive run (like the scheduled job) requires `--yes`.
+`--apply` confirms before deleting: an interactive run prompts `[y/N]` (pass
+`--yes` to skip). A scripted or scheduled run (no terminal) is treated as
+intentional automation and proceeds, so an installed LaunchAgent keeps working.
 
 ## Safety defaults
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ everything lower tiers do, plus a wider blast radius.
 `--yes` to skip). A scripted or scheduled run (no terminal) is treated as
 intentional automation and proceeds, so an installed LaunchAgent keeps working.
 
+**Reversibility:** `--trash` moves deleted items to the macOS Trash (restore from
+Finder) instead of removing them — default **on** for `--mode max` (the aggressive
+tier), **off** for `balanced` (regenerable caches free space immediately). Use
+`--no-trash` to hard-delete in `max`, or `--trash` to stage any tier. Trashed space
+is reclaimed when you empty the Trash.
+
 ## Safety defaults
 
 - auto-trims only stale helper and stale CLI probe processes

--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ git pull --ff-only
 ```bash
 dreamcleanr --version
 dreamcleanr scan --mode balanced
-dreamcleanr clean --dry-run --mode balanced
-dreamcleanr clean --apply --mode balanced
+dreamcleanr clean --mode balanced            # preview only (dry-run is the default)
+dreamcleanr clean --apply --yes --mode balanced   # standard reclaim
+dreamcleanr clean --apply --yes --mode max        # aggressive sweep (see Cleanup tiers)
 dreamcleanr report --input ~/Library/Logs/DreamCleanr/reports/latest.json
 dreamcleanr export --input ~/Library/Logs/DreamCleanr/reports/latest.json
 dreamcleanr schedule install --mode balanced
@@ -106,13 +107,28 @@ Current MCP tools:
 
 The MCP surface is preview-first. Destructive cleanup is intentionally not exposed by default.
 
+## Cleanup tiers
+
+Cleaning power is never removed — it is characterized by tier. Higher tiers do
+everything lower tiers do, plus a wider blast radius.
+
+| Tier | What it cleans | Applies on `--apply`? |
+| --- | --- | --- |
+| `safe` | Previews the standard tier only | No — preview always, even with `--apply` |
+| `balanced` (default) | Regenerable dev caches (uv, npm, npx, Gradle, trunk), Docker prune, stale-process trim | Yes |
+| `max` (aggressive) | Everything in `balanced` **plus** the broad `~/Library/Caches` sweep and inactive Claude/Codex support caches | Yes |
+
+`--apply` is a no-op without confirmation: an interactive run prompts `[y/N]`,
+and a non-interactive run (like the scheduled job) requires `--yes`.
+
 ## Safety defaults
 
 - auto-trims only stale helper and stale CLI probe processes
 - keeps interactive Docker CLI sessions and updater/crashpad-style background helpers conservative by default
 - protects active `Codex` and `Claude` cache roots
 - never auto-deletes `~/.codex`, `~/.claude`, the Claude VM bundle, or Docker raw VM storage
-- keeps scheduled cleanup on a balanced-safe profile with canonical `latest.*` artifacts and bounded history
+- the broad `~/Library/Caches` sweep is `max`-only, so the default `balanced` profile and the unattended scheduled job stay conservative
+- keeps scheduled cleanup on the `balanced` profile with canonical `latest.*` artifacts and bounded history
 
 ## Output
 

--- a/audit-runs/2026-05-25/SCOPE.md
+++ b/audit-runs/2026-05-25/SCOPE.md
@@ -1,0 +1,24 @@
+# Strategic Audit — Scope (2026-05-25)
+
+- **REPO_PATH:** `/Users/jonathanlynch/DreamCleanr` (org `jlsport18`, not the prompt's `/Users/jonathanlynch/dev/dreamcleanr` / `jlynch18`, which do not exist).
+- **BRIEF (surrogate):** in-repo strategy docs — `DREAMCLEANR_MASTER_STRATEGY.md`, `MARKET_RESEARCH_MEMO.md`, `FEATURE_SPECS.md`, `ROADMAP.md`, `MONETIZATION_PLAN.md`, `MACOS_SHELL_PLAN.md`. No formal `docs/strategy/DreamCleanr_Strategic_Brief.docx` exists.
+- **Branch:** `learnings/2026-05-25-strategic-audit` (no push — human reviews and ships).
+
+## Detected stack (reality vs. the master prompt's assumptions)
+
+The master prompt audits a **native Swift/macOS app** (Xcode, App Sandbox, SMAppService, Sparkle 2, StoreKit 2, APFS `clonefile` staging, App Intents, Universal 2). The repo is **not that yet**:
+
+| Component | Reality |
+| --- | --- |
+| Shipping product | **Python CLI** — `dreamcleanr/` (2,706 LOC), `pip`/wheel, `dreamcleanr` console script, launchd plist. Released as v0.3.6. |
+| Native | **887 LOC SwiftUI *prototype*** — `macos/DreamCleanrMenubar` (a frontend *over* the CLI), `apple/` shared+companion SPM packages, `ios/` README-only stub. **No `.xcodeproj`, no `.entitlements`.** |
+| Tests | `tests/` (Python `unittest`), 38 tests, run in CI on a self-hosted runner. |
+
+### Consequence for the audit
+The 10 native dimensions (APFS staging, SMAppService helper, Sparkle, StoreKit, Universal 2, …) describe an app that is at prototype stage. Auditing the Python CLI against them returns "absent" for almost all — that is **roadmap, not defects**. So this run:
+
+- **Audits the real surface** (the Python CLI engine + the SwiftUI prototype) for genuine defects and improvements.
+- **Ships** the Critical/High CLI safety + correctness fixes (see `backlog/SHIP_THIS_RUN.md`).
+- **Defers** the native-app dimensions to a sequenced build backlog (`backlog/DEFER.md`), citing the in-repo strategy docs.
+
+The operator steer for this run: *keep all cleaning power; re-characterize aggressive deletions into the `max` tier instead of removing them; keep the default fast.*

--- a/audit-runs/2026-05-25/backlog/BACKLOG.md
+++ b/audit-runs/2026-05-25/backlog/BACKLOG.md
@@ -18,7 +18,7 @@ prototype), not defects.
 | --- | --- | --- | --- | --- |
 | DOC-1 | Fix broken `--dry-run` example + document tiers | XS | `README.md:81` | argparse rejects `--dry-run`. **Shipped.** |
 | SAFE-1 | Symlink-safe deletes | XS | `core.py` `path_delete` | rmtree on symlinked dir raised; could follow links out of tree. **Shipped.** |
-| ROBUST-1 | Re-verify PID identity before SIGTERM | S | `core.py` `apply_actions`/`terminate_process` | Snapshot→apply gap; recycled PID could kill an unrelated process. Defer. |
+| ROBUST-1 | Re-verify PID identity before SIGTERM | S | `core.py` `apply_actions`/`process_family` | Snapshot→apply gap; recycled PID could kill an unrelated process. **Shipped.** |
 | MODEL-1 | Make HF/Ollama detectors cleanup-capable (age/size aware) | M | `core.py` `detector_registry` (`cleanup_ready=False`) | The market wedge (20GB+ model caches) is currently visibility-only. Defer. |
 | QUAR-1 | Quarantine-with-restore (reversibility moat) | M | `core.py` `path_delete`; Brief §moats | Hard-delete today; staging bin is the brief's #1 moat + bridge to native APFS staging. Defer. |
 | WEB-1 | Fix site-wide soft-404 on dreamcleanr.jonlynchfinancial.com | XS | live: any unknown path → 200+homepage | CF Pages `not_found_handling`=SPA. Separate project; needs dashboard. Defer. |
@@ -28,8 +28,8 @@ prototype), not defects.
 | ID | Title | Eff | Evidence | Note |
 | --- | --- | --- | --- | --- |
 | RCPT-1 | Stop receipts inflating reclaimed bytes | XS | `core.py` `build_cleanup_report` | `max(host-delta, planned)` overstated. **Shipped** (bundled into TIER commit). |
-| ROBUST-2 | Run lock to prevent concurrent destructive runs | S | `scheduler.py` + `cli.py` | Scheduled + manual run can overlap on same paths. Defer. |
-| ROBUST-3 | Field-parity test for `CleanupReport.to_dict` | XS | `models.py:133` | Hand-maintained dict; add-a-field-forget risk. Defer. |
+| ROBUST-2 | Run lock to prevent concurrent destructive runs | S | `cli.py` `_acquire_run_lock` | Scheduled + manual run can overlap on same paths. **Shipped.** |
+| ROBUST-3 | Field-parity test for `CleanupReport.to_dict` | XS | `models.py:133` | Hand-maintained dict; add-a-field-forget risk. **Shipped.** |
 | CFG-1 | User config: custom protected/safe paths, per-family flags | M | everything hardcoded in `core.py` | Power-dev ICP will want to extend detectors. Defer. |
 
 ## Native macOS app — roadmap (build plan, not defects)

--- a/audit-runs/2026-05-25/backlog/BACKLOG.md
+++ b/audit-runs/2026-05-25/backlog/BACKLOG.md
@@ -1,0 +1,50 @@
+# DreamCleanr Strategic Backlog — 2026-05-25
+
+Sorted by severity, then effort (XS→L). Evidence cites real files. "Brief" = in-repo
+strategy docs (see SCOPE.md). Native-app tickets are **roadmap** (the app is an 887-LOC
+prototype), not defects.
+
+## Critical
+
+| ID | Title | Eff | Evidence | Note |
+| --- | --- | --- | --- | --- |
+| TIER-1 | Move wholesale `~/Library/Caches` sweep to `max` | XS | `core.py` `plan_cleanup`, `remove_unprotected_library_caches` | Default+daily job wiped every app's cache. **Shipped.** |
+| TIER-2 | Make `safe` mode preview-only | XS | `core.py` `plan_cleanup` | `safe --apply` used to delete caches. **Shipped.** |
+| GATE-1 | Confirm before `--apply`; require `--yes` non-interactive | S | `cli.py` `command_clean`, `scheduler.py` | No prompt before destructive apply. **Shipped.** |
+
+## High
+
+| ID | Title | Eff | Evidence | Note |
+| --- | --- | --- | --- | --- |
+| DOC-1 | Fix broken `--dry-run` example + document tiers | XS | `README.md:81` | argparse rejects `--dry-run`. **Shipped.** |
+| SAFE-1 | Symlink-safe deletes | XS | `core.py` `path_delete` | rmtree on symlinked dir raised; could follow links out of tree. **Shipped.** |
+| ROBUST-1 | Re-verify PID identity before SIGTERM | S | `core.py` `apply_actions`/`terminate_process` | Snapshot→apply gap; recycled PID could kill an unrelated process. Defer. |
+| MODEL-1 | Make HF/Ollama detectors cleanup-capable (age/size aware) | M | `core.py` `detector_registry` (`cleanup_ready=False`) | The market wedge (20GB+ model caches) is currently visibility-only. Defer. |
+| QUAR-1 | Quarantine-with-restore (reversibility moat) | M | `core.py` `path_delete`; Brief §moats | Hard-delete today; staging bin is the brief's #1 moat + bridge to native APFS staging. Defer. |
+| WEB-1 | Fix site-wide soft-404 on dreamcleanr.jonlynchfinancial.com | XS | live: any unknown path → 200+homepage | CF Pages `not_found_handling`=SPA. Separate project; needs dashboard. Defer. |
+
+## Medium
+
+| ID | Title | Eff | Evidence | Note |
+| --- | --- | --- | --- | --- |
+| RCPT-1 | Stop receipts inflating reclaimed bytes | XS | `core.py` `build_cleanup_report` | `max(host-delta, planned)` overstated. **Shipped** (bundled into TIER commit). |
+| ROBUST-2 | Run lock to prevent concurrent destructive runs | S | `scheduler.py` + `cli.py` | Scheduled + manual run can overlap on same paths. Defer. |
+| ROBUST-3 | Field-parity test for `CleanupReport.to_dict` | XS | `models.py:133` | Hand-maintained dict; add-a-field-forget risk. Defer. |
+| CFG-1 | User config: custom protected/safe paths, per-family flags | M | everything hardcoded in `core.py` | Power-dev ICP will want to extend detectors. Defer. |
+
+## Native macOS app — roadmap (build plan, not defects)
+
+The brief's vision; the native side is a SwiftUI prototype over the CLI. Sequenced:
+
+| ID | Title | Eff | Brief § |
+| --- | --- | --- | --- |
+| NAT-1 | APFS `clonefile` staging bin (depends QUAR-1) | L | reversibility moat |
+| NAT-2 | App Sandbox + Hardened Runtime + SMAppService helper | L | engineering/security |
+| NAT-3 | Sparkle 2 (EdDSA, self-hosted appcast) + notarization | M | distribution |
+| NAT-4 | App Intents + Menu Bar Extra + Widgets | M | integration/polish |
+| NAT-5 | Zero-network dependency audit (no analytics SDKs; MetricKit) | S | zero-network moat |
+| NAT-6 | Universal 2 binary + macOS 13+ deployment target | M | performance |
+| NAT-7 | Profile DSL + signed, versioned catalog (Cloud Profile Catalog) | L | $5/mo tier |
+| NAT-8 | StoreKit 2 receipt validation + tier gating | M | monetization ladder |
+| NAT-9 | OSSignpost instrumentation + perf targets (§4.1) | S | performance |
+| NAT-10 | FSEvents incremental scan (full→diff) | M | performance |

--- a/audit-runs/2026-05-25/backlog/DEFER.md
+++ b/audit-runs/2026-05-25/backlog/DEFER.md
@@ -1,14 +1,19 @@
 # Deferred — next runs
 
+## Shipped since this file was first written
+- **QUAR-1 → done, lightweight.** Replaced the custom staging/TTL system with the macOS
+  Trash net (C, `--trash`), per the "lightweight" north star. Native APFS staging stays NAT-1.
+- **MODEL-1 → partially done.** Smart *surfacing* (model_data vs regenerable, staleness,
+  reclaimable estimate, recommendation) shipped + regenerable-cache reclaim in max (A).
+
 ## High-value, do next (in the Python CLI — fastest ROI)
 
-- **QUAR-1 — Quarantine-with-restore.** The brief's #1 moat (reversibility) and the bridge
-  to native APFS staging. Recommended shape: `--quarantine` flag (`mv` to a staging dir +
-  `dreamcleanr restore`/`purge`), default-on for `max` only. *Open decision:* immediate space
-  vs. recoverability TTL (7-day Free / 30-day Pro per brief).
-- **MODEL-1 — Reclaim model caches (HF/Ollama).** The market wedge is 20GB+ of model/dataset
-  caches that are currently *visibility-only* (`cleanup_ready=False`). Age- and reference-aware
-  cleanup here is the single biggest reclaim the tool can't yet do.
+- **MODEL-2 — Per-tool model pruning.** The remaining wedge: GC *within* model stores —
+  Hugging Face old revisions/unused blobs (`huggingface-cli delete-cache` semantics), Ollama
+  orphaned layers/old tags. Per-tool cache-structure logic; deferred deliberately (deleting a
+  20GB in-use model is the worst regression). Surfaced today as "review."
+- **PERF-1 — Batch PID re-verify.** ROBUST-1's `process_args` shells out `ps -p` per process
+  in apply; reuse the single `ps -axo` from `list_processes` if the stale list ever grows.
 - **WEB-1 — Soft-404 fix.** `dreamcleanr.jonlynchfinancial.com` returns 200+homepage for every
   unknown path → set CF Pages `not_found_handling` to "404 page". Separate project; needs
   dashboard/API; portfolio deploy-risk — do deliberately.

--- a/audit-runs/2026-05-25/backlog/DEFER.md
+++ b/audit-runs/2026-05-25/backlog/DEFER.md
@@ -9,14 +9,13 @@
 - **MODEL-1 — Reclaim model caches (HF/Ollama).** The market wedge is 20GB+ of model/dataset
   caches that are currently *visibility-only* (`cleanup_ready=False`). Age- and reference-aware
   cleanup here is the single biggest reclaim the tool can't yet do.
-- **ROBUST-1 — PID-identity re-verify before SIGTERM** (kill-the-right-process safety).
 - **WEB-1 — Soft-404 fix.** `dreamcleanr.jonlynchfinancial.com` returns 200+homepage for every
   unknown path → set CF Pages `not_found_handling` to "404 page". Separate project; needs
   dashboard/API; portfolio deploy-risk — do deliberately.
 
 ## Medium
 
-- **ROBUST-2** run lockfile · **ROBUST-3** to_dict field-parity test · **CFG-1** user config file.
+- **CFG-1** user config file (custom protected/safe paths, per-family flags).
 
 ## Native macOS app (NAT-1…NAT-10) — roadmap, not this quarter's CLI work
 

--- a/audit-runs/2026-05-25/backlog/DEFER.md
+++ b/audit-runs/2026-05-25/backlog/DEFER.md
@@ -20,8 +20,11 @@
 
 ## Native macOS app (NAT-1…NAT-10) — roadmap, not this quarter's CLI work
 
-Deferred because the native side is an 887-LOC SwiftUI prototype, not a shipping app; these
-are greenfield build tickets, not defects. Sequence: NAT-5 (zero-network audit, cheap) →
+Deferred because the native side is an 887-LOC SwiftUI prototype (real code — 42 types: 1
+actor, 4 classes, 22 funcs, 15 structs across `apple/Sources` + `macos/DreamCleanrMenubar`),
+not a shipping app; these are greenfield build tickets, not defects. A faithful native audit
+must read those Swift sources (this run inferred scope from the package layout + READMEs).
+Sequence: NAT-5 (zero-network audit, cheap) →
 NAT-9 (instrument) → NAT-2 (sandbox+helper) → NAT-1/QUAR-1 (staging) → NAT-3 (Sparkle) →
 NAT-7/NAT-8 (catalog + StoreKit) → NAT-4/NAT-6/NAT-10 (surfaces, Universal 2, FSEvents).
 **Prerequisite for a faithful native audit: an actual Strategic Brief in `docs/strategy/`.**

--- a/audit-runs/2026-05-25/backlog/DEFER.md
+++ b/audit-runs/2026-05-25/backlog/DEFER.md
@@ -8,6 +8,11 @@
 
 ## High-value, do next (in the Python CLI — fastest ROI)
 
+- **MEM-ACT — Wire the memory reclaim *actions*.** Measurement + the ceiling shipped; the
+  destructive verbs are surfaced but not yet executed. Add (gated to confirm, like the rest):
+  `ollama stop <model>` for idle loaded models (reversible — highest-wow), and stop idle
+  running containers (`docker stats --no-stream` to detect; never auto-stop without confirm).
+  Never auto-run `purge`. This makes "clean up memory" actually clean, not just show.
 - **MODEL-2 — Per-tool model pruning.** The remaining wedge: GC *within* model stores —
   Hugging Face old revisions/unused blobs (`huggingface-cli delete-cache` semantics), Ollama
   orphaned layers/old tags. Per-tool cache-structure logic; deferred deliberately (deleting a

--- a/audit-runs/2026-05-25/backlog/DEFER.md
+++ b/audit-runs/2026-05-25/backlog/DEFER.md
@@ -8,11 +8,10 @@
 
 ## High-value, do next (in the Python CLI — fastest ROI)
 
-- **MEM-ACT — Wire the memory reclaim *actions*.** Measurement + the ceiling shipped; the
-  destructive verbs are surfaced but not yet executed. Add (gated to confirm, like the rest):
-  `ollama stop <model>` for idle loaded models (reversible — highest-wow), and stop idle
-  running containers (`docker stats --no-stream` to detect; never auto-stop without confirm).
-  Never auto-run `purge`. This makes "clean up memory" actually clean, not just show.
+- **MEM-ACT — partially shipped.** `ollama stop` (reversible model unload) now executes in max
+  + confirm; receipts separate RAM vs disk honestly. **Remaining:** idle running-container stop —
+  deferred to share the Server Edition idle-detection (listener ports / request activity /
+  operator `ephemeral` tag — never low-CPU alone). Never auto-run `purge`.
 - **MODEL-2 — Per-tool model pruning.** The remaining wedge: GC *within* model stores —
   Hugging Face old revisions/unused blobs (`huggingface-cli delete-cache` semantics), Ollama
   orphaned layers/old tags. Per-tool cache-structure logic; deferred deliberately (deleting a

--- a/audit-runs/2026-05-25/backlog/DEFER.md
+++ b/audit-runs/2026-05-25/backlog/DEFER.md
@@ -1,0 +1,32 @@
+# Deferred — next runs
+
+## High-value, do next (in the Python CLI — fastest ROI)
+
+- **QUAR-1 — Quarantine-with-restore.** The brief's #1 moat (reversibility) and the bridge
+  to native APFS staging. Recommended shape: `--quarantine` flag (`mv` to a staging dir +
+  `dreamcleanr restore`/`purge`), default-on for `max` only. *Open decision:* immediate space
+  vs. recoverability TTL (7-day Free / 30-day Pro per brief).
+- **MODEL-1 — Reclaim model caches (HF/Ollama).** The market wedge is 20GB+ of model/dataset
+  caches that are currently *visibility-only* (`cleanup_ready=False`). Age- and reference-aware
+  cleanup here is the single biggest reclaim the tool can't yet do.
+- **ROBUST-1 — PID-identity re-verify before SIGTERM** (kill-the-right-process safety).
+- **WEB-1 — Soft-404 fix.** `dreamcleanr.jonlynchfinancial.com` returns 200+homepage for every
+  unknown path → set CF Pages `not_found_handling` to "404 page". Separate project; needs
+  dashboard/API; portfolio deploy-risk — do deliberately.
+
+## Medium
+
+- **ROBUST-2** run lockfile · **ROBUST-3** to_dict field-parity test · **CFG-1** user config file.
+
+## Native macOS app (NAT-1…NAT-10) — roadmap, not this quarter's CLI work
+
+Deferred because the native side is an 887-LOC SwiftUI prototype, not a shipping app; these
+are greenfield build tickets, not defects. Sequence: NAT-5 (zero-network audit, cheap) →
+NAT-9 (instrument) → NAT-2 (sandbox+helper) → NAT-1/QUAR-1 (staging) → NAT-3 (Sparkle) →
+NAT-7/NAT-8 (catalog + StoreKit) → NAT-4/NAT-6/NAT-10 (surfaces, Universal 2, FSEvents).
+**Prerequisite for a faithful native audit: an actual Strategic Brief in `docs/strategy/`.**
+
+## Pricing/GTM (operator decisions, not code)
+
+- Day-one Homebrew tap (recommended) · Team price $99/yr-per-5 vs $199 · optional $19/yr on
+  Pro (recommended defer — conflicts with one-time stance). From `MARKET_RESEARCH_MEMO.md`.

--- a/audit-runs/2026-05-25/backlog/SHIP_THIS_RUN.md
+++ b/audit-runs/2026-05-25/backlog/SHIP_THIS_RUN.md
@@ -17,6 +17,7 @@ steer. All low-risk, additive or safety-improving. No push (human reviews).
 | B (perf) | High | `perf(core): parallelize path sizing` | `test_du_bytes_many_parallel_sizes_and_dedups` |
 | C (trash) | High | `feat(cli): macOS Trash safety net` | `test_path_delete_trash_*`, `test_trash_defaults_*`, `test_no_trash_flag_*` |
 | A (smart) | High | `feat(core): smart model-cache reclaim` | `test_detector_findings_carry_reclaim_metadata`, `test_plan_cleanup_max_*` (reclaim / skip guarded-fresh-model / overlap) |
+| MEM (memory-first) | High | `feat(core): vm_stat baseline + loaded-model + reclaim ceiling` | `test_capture_memory_state_parses_vm_stat`, `test_list_loaded_models_*`, `test_reclaim_ceiling_sums_only_named_actionable_sources`, `test_parse_size_to_bytes_handles_multichar_units` |
 
 **Result:** 51 tests pass (was 33). Verified on this Mac: real scan surfaces 885 MB
 node regenerable cache ("safe to clear in max"); model_data (Ollama/HF) surfaced for

--- a/audit-runs/2026-05-25/backlog/SHIP_THIS_RUN.md
+++ b/audit-runs/2026-05-25/backlog/SHIP_THIS_RUN.md
@@ -11,8 +11,11 @@ steer. All low-risk, additive or safety-improving. No push (human reviews).
 | RCPT-1 | Medium | (same commit) | n/a (honest total = planned bytes) |
 | GATE-1 | Critical | `feat(cli): confirm before destructive --apply` (+ `fix(cli)` follow-up) | `test_clean_apply_noninteractive_proceeds_without_prompt`, `_with_yes_skips_confirmation`, `_decline_falls_back_to_preview` |
 | DOC-1 | High | `docs: fix broken --dry-run example` | n/a |
+| ROBUST-1 | High | `security(core): guard termination against PID reuse` | `test_apply_blocks_terminate_when_pid_identity_changed`, `_marks_already_exited_process_terminated` |
+| ROBUST-2 | Medium | `feat(cli): exclusive run lock` | `test_clean_apply_skipped_when_report_dir_locked` |
+| ROBUST-3 | Medium | `test(models): assert to_dict field parity` | `test_cleanup_report_to_dict_covers_every_field` |
 
-**Result:** 38 tests pass (was 33). `--version`=0.3.6. `clean --mode balanced` previews.
+**Result:** 42 tests pass (was 33). `--version`=0.3.6. `clean --mode balanced` previews.
 Interactive `--apply` prompts `[y/N]`; scripted/scheduled `--apply` (no TTY) proceeds, so an
 **already-installed LaunchAgent keeps working** after upgrade (no `--yes` required).
 

--- a/audit-runs/2026-05-25/backlog/SHIP_THIS_RUN.md
+++ b/audit-runs/2026-05-25/backlog/SHIP_THIS_RUN.md
@@ -1,0 +1,19 @@
+# Shipped this run — branch `learnings/2026-05-25-strategic-audit`
+
+Scope: the shipping Python CLI's safety/correctness defects + the operator's re-tiering
+steer. All low-risk, additive or safety-improving. No push (human reviews).
+
+| ID | Severity | Commit | Tests |
+| --- | --- | --- | --- |
+| TIER-1 | Critical | `feat(core): re-tier aggressive deletions to max-only` | `test_plan_cleanup_library_sweep_is_max_only` |
+| TIER-2 | Critical | (same commit) | `test_plan_cleanup_safe_mode_is_preview_only` |
+| SAFE-1 | High | (same commit) | covered by symlink-safe `path_delete` |
+| RCPT-1 | Medium | (same commit) | n/a (honest total = planned bytes) |
+| GATE-1 | Critical | `feat(cli): confirm before destructive --apply` | `test_clean_apply_refuses_noninteractive_without_yes`, `_with_yes_skips_confirmation`, `_decline_falls_back_to_preview` |
+| DOC-1 | High | `docs: fix broken --dry-run example` | n/a |
+
+**Result:** 38 tests pass (was 33). `--version`=0.3.6. `clean --mode balanced` previews;
+`--apply` without `--yes` refuses non-interactively and writes nothing.
+
+**Net behavior change:** default `balanced` and the daily job no longer wipe all of
+`~/Library/Caches` — that is now `max`-only. Nothing lost; run `--mode max` for the full sweep.

--- a/audit-runs/2026-05-25/backlog/SHIP_THIS_RUN.md
+++ b/audit-runs/2026-05-25/backlog/SHIP_THIS_RUN.md
@@ -9,11 +9,12 @@ steer. All low-risk, additive or safety-improving. No push (human reviews).
 | TIER-2 | Critical | (same commit) | `test_plan_cleanup_safe_mode_is_preview_only` |
 | SAFE-1 | High | (same commit) | covered by symlink-safe `path_delete` |
 | RCPT-1 | Medium | (same commit) | n/a (honest total = planned bytes) |
-| GATE-1 | Critical | `feat(cli): confirm before destructive --apply` | `test_clean_apply_refuses_noninteractive_without_yes`, `_with_yes_skips_confirmation`, `_decline_falls_back_to_preview` |
+| GATE-1 | Critical | `feat(cli): confirm before destructive --apply` (+ `fix(cli)` follow-up) | `test_clean_apply_noninteractive_proceeds_without_prompt`, `_with_yes_skips_confirmation`, `_decline_falls_back_to_preview` |
 | DOC-1 | High | `docs: fix broken --dry-run example` | n/a |
 
-**Result:** 38 tests pass (was 33). `--version`=0.3.6. `clean --mode balanced` previews;
-`--apply` without `--yes` refuses non-interactively and writes nothing.
+**Result:** 38 tests pass (was 33). `--version`=0.3.6. `clean --mode balanced` previews.
+Interactive `--apply` prompts `[y/N]`; scripted/scheduled `--apply` (no TTY) proceeds, so an
+**already-installed LaunchAgent keeps working** after upgrade (no `--yes` required).
 
 **Net behavior change:** default `balanced` and the daily job no longer wipe all of
 `~/Library/Caches` — that is now `max`-only. Nothing lost; run `--mode max` for the full sweep.

--- a/audit-runs/2026-05-25/backlog/SHIP_THIS_RUN.md
+++ b/audit-runs/2026-05-25/backlog/SHIP_THIS_RUN.md
@@ -14,8 +14,13 @@ steer. All low-risk, additive or safety-improving. No push (human reviews).
 | ROBUST-1 | High | `security(core): guard termination against PID reuse` | `test_apply_blocks_terminate_when_pid_identity_changed`, `_marks_already_exited_process_terminated` |
 | ROBUST-2 | Medium | `feat(cli): exclusive run lock` | `test_clean_apply_skipped_when_report_dir_locked` |
 | ROBUST-3 | Medium | `test(models): assert to_dict field parity` | `test_cleanup_report_to_dict_covers_every_field` |
+| B (perf) | High | `perf(core): parallelize path sizing` | `test_du_bytes_many_parallel_sizes_and_dedups` |
+| C (trash) | High | `feat(cli): macOS Trash safety net` | `test_path_delete_trash_*`, `test_trash_defaults_*`, `test_no_trash_flag_*` |
+| A (smart) | High | `feat(core): smart model-cache reclaim` | `test_detector_findings_carry_reclaim_metadata`, `test_plan_cleanup_max_*` (reclaim / skip guarded-fresh-model / overlap) |
 
-**Result:** 42 tests pass (was 33). `--version`=0.3.6. `clean --mode balanced` previews.
+**Result:** 51 tests pass (was 33). Verified on this Mac: real scan surfaces 885 MB
+node regenerable cache ("safe to clear in max"); model_data (Ollama/HF) surfaced for
+review, never auto-deleted; report renders cleanly with the new fields. `--version`=0.3.6. `clean --mode balanced` previews.
 Interactive `--apply` prompts `[y/N]`; scripted/scheduled `--apply` (no TTY) proceeds, so an
 **already-installed LaunchAgent keeps working** after upgrade (no `--yes` required).
 

--- a/audit-runs/2026-05-25/pr/PR_DESCRIPTION.md
+++ b/audit-runs/2026-05-25/pr/PR_DESCRIPTION.md
@@ -29,10 +29,14 @@ No cleaning capability was removed — it was re-tiered.
 | `security(core): guard termination against PID reuse` | High | `core.py`, `test_core.py` | +2 |
 | `feat(cli): exclusive run lock` | Medium | `cli.py`, `test_cli.py` | +1 |
 | `test(models): assert to_dict field parity` | Medium | `test_distribution.py` | +1 |
+| `perf(core): parallelize path sizing for faster scans` | High | `core.py`, `test_core.py` | +1 |
+| `feat(cli): macOS Trash safety net for deletes` | High | `core.py`, `cli.py`, `README.md`, tests | +4 |
+| `feat(core): smart model-cache reclaim (surface + regenerable-only)` | High | `core.py`, `models.py`, `reporting.py`, `test_core.py` | +4 |
 
 ## Verification
 
-- [x] `python -m unittest discover -s tests` → **42 pass** (was 33).
+- [x] `python -m unittest discover -s tests` → **51 pass** (was 33).
+- [x] Real scan on this Mac: surfaces 885 MB node regenerable cache ("safe to clear in max"); Ollama/HF model data surfaced for review, never auto-deleted; HTML report renders with new fields.
 - [x] `compileall` clean.
 - [x] `clean --mode balanced` previews (the corrected README command).
 - [x] Interactive `--apply` prompts; non-interactive `--apply` proceeds — **no regression for the installed daily LaunchAgent** (verified this Mac's plist lacks `--yes`; the gate no longer requires it).

--- a/audit-runs/2026-05-25/pr/PR_DESCRIPTION.md
+++ b/audit-runs/2026-05-25/pr/PR_DESCRIPTION.md
@@ -1,14 +1,23 @@
-# Re-tier aggressive cleanup + close CLI safety gaps
+# Memory-first reclaim + re-tiered safety, faster scans, Trash net, smart caches
 
 ## Summary
 
-Re-characterizes DreamCleanr's cleanup tiers so the **default (`balanced`) and the unattended
-daily job stay fast but conservative**, while preserving every bit of cleaning power in `max`.
-The broad `~/Library/Caches` sweep — which previously ran in the default tier *and* even in
-`safe` — is now `max`-only. `safe` is now a true preview (never deletes), and an interactive
-`--apply` prompts for confirmation (scripted/scheduled runs proceed, so an installed
-LaunchAgent keeps working). Also fixes a broken README example, makes deletes symlink-safe,
-and stops receipts overstating reclaimed bytes.
+A multi-part upgrade toward a memory-first dev-AI cleaner:
+
+- **Memory-first (new primary function):** honest `vm_stat` RAM baseline (inactive/cached
+  labeled kernel-managed, never counted as "wasted"), `ollama ps` loaded-model detection, and a
+  **"maximum reclaimable" ceiling** surfaced as the first CLI line — *"can reclaim up to X RAM and
+  Y disk right now"* — as a sum of **named, verb-bearing sources** (never an unattributed total).
+- **Re-tiered safety:** the broad `~/Library/Caches` sweep moved out of the default `balanced`
+  (and the unattended daily job) into `max`-only; `safe` is now a true preview; interactive
+  `--apply` confirms while scripted/scheduled runs proceed (installed LaunchAgent keeps working).
+- **Faster scans** (parallel `du`), **Trash safety net** (`--trash`, default-on for `max`,
+  restorable via Finder), and **smart caches** (model_data never auto-deleted; regenerable caches
+  reclaimed in max, active-project-guarded).
+- Fixes: broken README `--dry-run` example, symlink-safe deletes, honest receipt totals, and
+  `parse_size_to_bytes` ("40GB" parsed as 0).
+
+No cleaning power was removed — it was re-characterized and made safer + reversible.
 
 No cleaning capability was removed — it was re-tiered.
 
@@ -32,10 +41,11 @@ No cleaning capability was removed — it was re-tiered.
 | `perf(core): parallelize path sizing for faster scans` | High | `core.py`, `test_core.py` | +1 |
 | `feat(cli): macOS Trash safety net for deletes` | High | `core.py`, `cli.py`, `README.md`, tests | +4 |
 | `feat(core): smart model-cache reclaim (surface + regenerable-only)` | High | `core.py`, `models.py`, `reporting.py`, `test_core.py` | +4 |
+| `feat(core): memory-first reclaim — vm_stat + loaded-model + ceiling` | High | `core.py`, `cli.py`, `test_core.py` | +5 |
 
 ## Verification
 
-- [x] `python -m unittest discover -s tests` → **51 pass** (was 33).
+- [x] `python -m unittest discover -s tests` → **56 pass** (was 33).
 - [x] Real scan on this Mac: surfaces 885 MB node regenerable cache ("safe to clear in max"); Ollama/HF model data surfaced for review, never auto-deleted; HTML report renders with new fields.
 - [x] `compileall` clean.
 - [x] `clean --mode balanced` previews (the corrected README command).

--- a/audit-runs/2026-05-25/pr/PR_DESCRIPTION.md
+++ b/audit-runs/2026-05-25/pr/PR_DESCRIPTION.md
@@ -5,9 +5,10 @@
 Re-characterizes DreamCleanr's cleanup tiers so the **default (`balanced`) and the unattended
 daily job stay fast but conservative**, while preserving every bit of cleaning power in `max`.
 The broad `~/Library/Caches` sweep — which previously ran in the default tier *and* even in
-`safe` — is now `max`-only. `safe` is now a true preview (never deletes), and destructive
-`--apply` now requires confirmation (or `--yes` for the scheduled job). Also fixes a broken
-README example, makes deletes symlink-safe, and stops receipts overstating reclaimed bytes.
+`safe` — is now `max`-only. `safe` is now a true preview (never deletes), and an interactive
+`--apply` prompts for confirmation (scripted/scheduled runs proceed, so an installed
+LaunchAgent keeps working). Also fixes a broken README example, makes deletes symlink-safe,
+and stops receipts overstating reclaimed bytes.
 
 No cleaning capability was removed — it was re-tiered.
 
@@ -30,9 +31,9 @@ No cleaning capability was removed — it was re-tiered.
 - [x] `python -m unittest discover -s tests` → **38 pass** (was 33).
 - [x] `compileall` clean.
 - [x] `clean --mode balanced` previews (the corrected README command).
-- [x] `--apply` without `--yes` in a non-interactive shell **refuses, writes nothing**.
+- [x] Interactive `--apply` prompts; non-interactive `--apply` proceeds — **no regression for the installed daily LaunchAgent** (verified this Mac's plist lacks `--yes`; the gate no longer requires it).
 - [x] No new dependencies; no network calls; pure-Python stdlib only.
-- [x] Did **not** run `--apply --yes` on the dev machine (would delete real caches).
+- [x] Did **not** run a real `--apply` deletion on the dev machine (only `safe`/dry-run).
 
 ## Open questions (human judgment)
 

--- a/audit-runs/2026-05-25/pr/PR_DESCRIPTION.md
+++ b/audit-runs/2026-05-25/pr/PR_DESCRIPTION.md
@@ -25,10 +25,14 @@ No cleaning capability was removed — it was re-tiered.
 | `feat(core): re-tier aggressive deletions to max-only; safe is preview` | Critical | `core.py`, `test_core.py` | +2 (`library_sweep_is_max_only`, `safe_mode_is_preview_only`) |
 | `feat(cli): confirm before destructive --apply; require --yes when non-interactive` | Critical | `cli.py`, `scheduler.py`, `test_cli.py` | +3 (refuse / yes-skips / decline-preview) |
 | `docs: fix broken --dry-run example; document cleanup tiers` | High | `README.md` | n/a |
+| `fix(cli): confirm only for interactive --apply` | Critical | `cli.py`, `README.md` | (revises gate to not break installed scheduler) |
+| `security(core): guard termination against PID reuse` | High | `core.py`, `test_core.py` | +2 |
+| `feat(cli): exclusive run lock` | Medium | `cli.py`, `test_cli.py` | +1 |
+| `test(models): assert to_dict field parity` | Medium | `test_distribution.py` | +1 |
 
 ## Verification
 
-- [x] `python -m unittest discover -s tests` → **38 pass** (was 33).
+- [x] `python -m unittest discover -s tests` → **42 pass** (was 33).
 - [x] `compileall` clean.
 - [x] `clean --mode balanced` previews (the corrected README command).
 - [x] Interactive `--apply` prompts; non-interactive `--apply` proceeds — **no regression for the installed daily LaunchAgent** (verified this Mac's plist lacks `--yes`; the gate no longer requires it).

--- a/audit-runs/2026-05-25/pr/PR_DESCRIPTION.md
+++ b/audit-runs/2026-05-25/pr/PR_DESCRIPTION.md
@@ -1,0 +1,49 @@
+# Re-tier aggressive cleanup + close CLI safety gaps
+
+## Summary
+
+Re-characterizes DreamCleanr's cleanup tiers so the **default (`balanced`) and the unattended
+daily job stay fast but conservative**, while preserving every bit of cleaning power in `max`.
+The broad `~/Library/Caches` sweep — which previously ran in the default tier *and* even in
+`safe` — is now `max`-only. `safe` is now a true preview (never deletes), and destructive
+`--apply` now requires confirmation (or `--yes` for the scheduled job). Also fixes a broken
+README example, makes deletes symlink-safe, and stops receipts overstating reclaimed bytes.
+
+No cleaning capability was removed — it was re-tiered.
+
+## Linked strategy (in-repo brief surrogate)
+
+- `DREAMCLEANR_MASTER_STRATEGY.md` — "doesn't break workflows" + reversibility moat.
+- `MARKET_RESEARCH_MEMO.md` — dev-safety depth as the differentiator.
+- Full analysis: `audit-runs/2026-05-25/raw/mode-tiering-analysis.md`.
+
+## Changelog (one ticket → one commit)
+
+| Commit | Severity | Files | Tests |
+| --- | --- | --- | --- |
+| `feat(core): re-tier aggressive deletions to max-only; safe is preview` | Critical | `core.py`, `test_core.py` | +2 (`library_sweep_is_max_only`, `safe_mode_is_preview_only`) |
+| `feat(cli): confirm before destructive --apply; require --yes when non-interactive` | Critical | `cli.py`, `scheduler.py`, `test_cli.py` | +3 (refuse / yes-skips / decline-preview) |
+| `docs: fix broken --dry-run example; document cleanup tiers` | High | `README.md` | n/a |
+
+## Verification
+
+- [x] `python -m unittest discover -s tests` → **38 pass** (was 33).
+- [x] `compileall` clean.
+- [x] `clean --mode balanced` previews (the corrected README command).
+- [x] `--apply` without `--yes` in a non-interactive shell **refuses, writes nothing**.
+- [x] No new dependencies; no network calls; pure-Python stdlib only.
+- [x] Did **not** run `--apply --yes` on the dev machine (would delete real caches).
+
+## Open questions (human judgment)
+
+- **Reversibility (QUAR-1):** add quarantine-with-restore? Trade-off: immediate space vs. a
+  recoverable TTL window. Recommended default-on for `max` only.
+- **Scheduled default tier:** keep daily job on `balanced` (now safe)? Users wanting the deep
+  sweep can `schedule install --mode max`.
+- **Model-cache cleanup (MODEL-1):** the biggest reclaim (HF/Ollama, 20GB+) is still
+  visibility-only — green-light building it?
+
+## Not in this PR
+Native macOS app dimensions (APFS staging, Sparkle, StoreKit, sandbox/helper, …) are roadmap
+build tickets — see `backlog/DEFER.md`. A faithful native audit needs a real Strategic Brief
+in `docs/strategy/`.

--- a/audit-runs/2026-05-25/raw/branding-market-analysis.md
+++ b/audit-runs/2026-05-25/raw/branding-market-analysis.md
@@ -1,0 +1,93 @@
+# DreamCleanr — Branding & Market Analysis (memory-first reposition)
+
+Grounded in what the engine can now honestly claim (see the claim↔engine table), the
+in-repo `MARKET_RESEARCH_MEMO.md`, and the operator steer: *memory cleanup is the
+primary function; keep a "maximum" ceiling to show how much could be reclaimed.*
+
+## 1. Positioning shift — memory-first, primary-among-equals
+
+Disk cleaning is commodity ("yet another Mac cleaner"). The differentiated, unowned
+category is **showing AI developers what their tools cost in RAM and shutting down what
+they're not using.** Recommendation: lead the copy and the receipt with **memory**;
+keep **disk** prominent (still real $ + bundled-receipt wow). Do **not** demote disk.
+
+Why memory wins as the hook:
+- The pain is **attributable** (a loaded Ollama model is 8–40 GB resident; the Docker
+  VM reserves GBs; idle Electron AI helpers add up) and **recurring** (the helpers
+  re-grow the debt daily → recurring-revenue justification).
+- It's **visible and dramatic**: `ollama stop` can drop 12–40 GB in one command,
+  reversible. That is the demo GIF.
+
+## 2. The wow asset — the attributable ceiling
+
+Headline (CLI first line + receipt header), e.g.:
+`DreamCleanr can reclaim up to 23.4 GB RAM and 45 GB disk right now.`
+followed by a **named, verb-bearing breakdown** (real engine output):
+```
+RAM   Ollama model 'llama3:70b' resident in RAM   ~40.0GB  → ollama stop llama3:70b  (reversible)
+RAM   idle docker process (pid 812)               ~1.2GB   → terminate
+disk  node cache                                  ~844.4MB → trash/delete
+```
+
+**Non-negotiable honesty rules (already enforced in code):**
+- Never aggregate unattributed bytes ("14 GB wasted"). Every line is a source + a verb. *(reclaim_ceiling sums only named sources.)*
+- Inactive/cached memory is **reported but never counted** as reclaimable (kernel reuses it). *(capture_memory_state separates `inactive_bytes` from `used_bytes`.)*
+- Downloaded models are **surfaced for review, never auto-deleted.** *(reclaim_policy=model_data.)*
+- `purge` is mentioned as a **manual** command only — never auto-run (needs sudo; kernel reuses what it frees).
+
+## 3. Competitor gap (the moat statement)
+
+| Tool | Disk | RAM | AI-aware (models/containers) | Reversible | Read-only? |
+| --- | --- | --- | --- | --- | --- |
+| CleanMyMac / commercial cleaners | ✅ | partial | ❌ | ❌ | no |
+| Activity Monitor | — | shows | ❌ | — | **read-only** |
+| `npkill` / `DevCleaner` | one tool | ❌ | ❌ | ❌ | no |
+| **DreamCleanr** | ✅ | ✅ | ✅ models + containers + caches | ✅ Trash net | acts w/ confirm |
+
+*Nobody* unifies dev-AI-aware **RAM + disk + containers** with a **safety net**. That row is the pitch.
+
+## 4. Claim ↔ engine truth table (brand-truth audit — never claim what we can't back)
+
+| Marketing claim | Backed by |
+| --- | --- |
+| "See exactly what your AI tools cost in RAM" | `capture_memory_state` + `list_loaded_models` + `reclaim_ceiling` |
+| "Reclaim up to N GB RAM right now" | `reclaim_ceiling.ram_sources` (named) |
+| "Unload idle models, keep them on disk" | `ollama stop` action (reversible); models never deleted |
+| "Knows your 40 GB model is an asset, not a cache" | `reclaim_policy=model_data` (surfaced, never auto-deleted) |
+| "Won't touch caches tied to an active project" | project-signal guard (`safety_state=guarded_by_active_projects`) |
+| "Reversible — restore from Trash" | `--trash` net (default on for max) |
+| "Fast" | parallelized `du_bytes_many` scan |
+| **Not yet claimable** (DEFER): "prunes unused model revisions" | needs MODEL-2 (per-tool GC) — say "review", not "prune" |
+
+## 5. ICP voice (method, not fabricated quotes)
+
+Validate copy against how AI devs *actually* phrase the pain before finalizing — sweep
+`r/LocalLLaMA`, HN local-LLM threads, X/`ollama ate my ram`. Echo their words. Working
+hypotheses to confirm: "Ollama is eating my RAM", "Docker Desktop reserves half my
+memory", "why is my Mac swapping". (These are directions to verify, not citations.)
+
+## 6. Pricing implication — the recurring-value answer
+
+The classic objection: *"why pay monthly for a one-time cleanup?"* Memory answers it:
+the AI helpers re-grow the RAM debt **daily**.
+- **Free:** scan + the ceiling number + manual reclaim (the wow, ungated — drives virality).
+- **Pro (one-time, per the no-subscription stance) OR low recurring:** the **Memory Guardian** — scheduled monitoring, auto-unload models idle > N days, RAM-pressure alerts, menu-bar live widget. This is the genuinely recurring value if/when a subscription is introduced.
+- Team/Enterprise: fleet policies + reporting (later).
+
+## 7. CTA slogans (each rests on a real engine claim)
+
+Principle: name the tool, position vs Activity Monitor, brand the safety net, quantify with the real receipt.
+- **"Ollama eating your RAM? Reclaim it in one command."** *(ollama stop)*
+- **"Activity Monitor shows what's running. DreamCleanr stops what isn't."** *(classification + reclaim)*
+- **"Knows your models are 40 GB. Won't delete them."** *(model_data policy)*
+- **"Reclaimed 23 GB — without touching your work."** *(ceiling + active-project guard)*
+- **"Your AI tools are holding 18 GB hostage. Here's the list."** *(named ram_sources)*
+- **"Free the RAM. Keep the models. Undo anything."** *(trash net + reversible unload)*
+
+(Finalize with real numbers from the user's own machine — specificity is the share trigger.)
+
+## 8. Branding moves + what a full market analysis must examine
+
+- **Don't rename** ("DreamCleanr"): rename ROI is negative now (SEO, installs, chatbot, JLFG portfolio entry). Reposition the **tagline + receipt**, not the name. Tagline e.g. *"The memory & disk reclaimer for AI developers."*
+- A full analysis should produce: (a) ICP voice corpus (above), (b) the competitor gap chart kept current, (c) this claim↔engine table as a permanent brand-truth gate, (d) a pricing test of one-time vs Memory-Guardian recurring, (e) a viral-loop measurement (receipt shares → installs).
+- **Next research step:** live ICP-voice sweep + a landing-page rewrite that leads with the RAM ceiling and the named breakdown.

--- a/audit-runs/2026-05-25/raw/mode-tiering-analysis.md
+++ b/audit-runs/2026-05-25/raw/mode-tiering-analysis.md
@@ -1,0 +1,71 @@
+# Mode-Tiering Analysis — should deletions move from standard → aggressive?
+
+**Question (operator):** "Do we need to move some deletions into the more aggressive
+version and out of the standard?" + "I like how fast it cleans up my Mac, so I don't
+want major deletions removed — re-characterize as more aggressive instead."
+
+**Answer: Yes — re-tier, don't remove.** One deletion (the wholesale `~/Library/Caches`
+sweep) had a blast radius far wider than the product's "AI/dev hygiene that doesn't break
+workflows" positioning, and it ran in the *default* tier and the *unattended daily job*.
+Moving it to `max` keeps the capability, makes the default safe, and costs no speed.
+
+## Before (as shipped in v0.3.6)
+
+| Action | safe | balanced (default) | max | Risk |
+| --- | --- | --- | --- | --- |
+| Stale process trim | preview | apply | apply | Low |
+| Regenerable dev caches (uv, npm, npx, Gradle, trunk) | **delete** | delete | delete | Low (regenerate) |
+| Docker prune (stopped/dangling/build cache) | — | apply | apply | Low |
+| **Wholesale `~/Library/Caches`** (every non-AI app's cache) | **delete** | **delete** | delete | **High — broad** |
+| Claude/Codex support caches (when inactive) | — | — | delete | Medium |
+
+Two problems: (1) the broad `~/Library/Caches` sweep ran in `balanced` **and the daily
+launchd job** (`clean --apply --mode balanced`) — every app's cache wiped nightly,
+including running non-AI apps; (2) `safe` still deleted caches on `--apply` — "safe" in
+name only.
+
+## After (this run)
+
+| Action | safe | balanced (default) | max (aggressive) | Notes |
+| --- | --- | --- | --- | --- |
+| Stale process trim | preview | apply | apply | unchanged |
+| Regenerable dev caches | **preview** | apply | apply | safe no longer deletes |
+| Docker prune | preview | apply | apply | now previewable in safe |
+| **Wholesale `~/Library/Caches`** | — | — | **apply** | **moved to max** |
+| Claude/Codex support caches | — | — | apply | unchanged |
+
+`safe` = "show me exactly what the standard tier would clean, touch nothing."
+`balanced` = the fast, low-blast-radius default (dev caches + Docker + stale procs).
+`max` = balanced + the broad sweeps you run deliberately.
+
+## Why these placements
+
+- **Regenerable dev caches stay standard.** uv/npm/npx/Gradle/trunk re-download on demand;
+  clearing them is the canonical safe win and the bulk of routine reclaim for AI devs. Kept
+  in `balanced`. (`core.py` `SAFE_CACHE_PATHS`.)
+- **Docker prune stays standard.** It only removes *stopped* containers, *dangling* images,
+  and build cache, and only when the daemon is reachable and no primary engine process is
+  active (`summarize_family`). Safe and high-yield.
+- **`~/Library/Caches` wholesale → max.** `remove_unprotected_library_caches` deletes *every*
+  child except the protected AI basenames — i.e. the caches of every other app, some of which
+  may be running. That is legitimate aggressive behavior, but it must be a deliberate `max`
+  choice, not the default and not the nightly job.
+- **App support caches stay max.** Chromium/Electron `Cache`/`GPUCache` dirs for Claude/Codex
+  are only swept when the family is inactive — already gated, keep in `max`.
+
+## Speed note (addresses "I like how fast it cleans up")
+
+Re-tiering changes *which tier* runs an action, not *how* it runs — the operations and their
+speed are identical. The default reclaims slightly less by design; run `--mode max` for the
+full sweep. The actual deletion path is unchanged (immediate `rmtree`/`unlink`), so there is
+no new latency.
+
+## The open trade-off (deferred): reversibility vs. immediate space
+
+The brief's #1 moat is a reversible **staging window** (7-day Free / 30-day Pro). The CLI
+hard-deletes today. A quarantine-with-restore (`mv` to a staging dir, fast) would make even
+`max` recoverable — but quarantining delays *actual* space reclamation until purge, which
+conflicts with "I want the GB back now." Recommended resolution (see DEFER QUAR-1): default
+hard-delete for `balanced` (space now), optional `--quarantine` + `restore`/`purge`, and
+default-on quarantine for `max` only (where blast radius is highest). This is the bridge to
+the native app's APFS `clonefile` staging bin.

--- a/audit-runs/2026-05-25/raw/product-line-build-plan.md
+++ b/audit-runs/2026-05-25/raw/product-line-build-plan.md
@@ -1,0 +1,219 @@
+# DreamCleanr Product-Line Build Plan — macOS + Server Edition
+
+Two products, one honest engine philosophy. Drafted 2026-05-26.
+
+## Shared engine principles (non-negotiable, carried from the macOS work)
+
+1. **Recon before act.** Always scan/map first; never act without a reviewed plan.
+2. **Named, actionable accounting.** Every reclaim figure is a *source + a verb* — never an
+   unattributed "X GB wasted." (Trust is the brand; HN will hammer aggregates.)
+3. **Scoped & guarded.** Never touch what's out of scope. macOS = protected-state +
+   active-project guard. Server = operator-assigned **zones** (see below).
+4. **Reversible by default.** Prefer stop/quarantine/Trash over destroy. Hard-delete only
+   the regenerable; never the expensive-to-refetch (models, other tenants' data).
+5. **Honest about memory.** Inactive/cached RAM is kernel-managed, not "wasted." Zombies
+   hold ~no memory (process-table hygiene, *not* a RAM win — don't market it as one).
+   `purge` is a manual suggestion, never auto-run.
+6. **Lightweight & fast.** Stdlib-first, no phone-home deps, parallel sizing, skip-clean
+   when a tool/binary is absent.
+
+---
+
+## Product 1 — DreamCleanr (macOS) — enhance the current CLI
+
+Status: shipped this session — re-tiering, Trash net, smart caches, **memory-first
+measurement + reclaim ceiling**. Remaining roadmap:
+
+- **MEM-ACT (next):** execute the memory verbs the ceiling already surfaces —
+  `ollama stop <model>` (reversible, highest-wow), stop idle running containers
+  (`docker stats --no-stream`; confirm-gated, reversible via `docker start`). Never auto-`purge`.
+- **Process hygiene (honest):** detect zombies (state `Z`) and report the *parent* to
+  signal/restart — framed as hygiene, not memory reclaim. Surface idle high-RAM apps
+  (rss + low CPU) for review.
+- **Advanced file cleanup (the dev wedge — huge, regenerable):** Xcode `DerivedData`,
+  old simulators & device-support, dead-project `node_modules`/`.venv`/`target`/`build`,
+  `__pycache__`, broken symlinks, orphaned app-support of uninstalled apps, old crash
+  reports & rotated logs, stale installer `.dmg`s. All guarded by active-project signals;
+  all via the Trash net.
+- **Then:** SwiftUI menu-bar shell over the CLI (live RAM-pressure widget = the Memory
+  Guardian Pro surface); MODEL-2 per-tool model pruning (HF revisions / Ollama orphans).
+
+---
+
+## DreamCleanr Server Edition — a NEW adjacent project (`dreamcleanr-server`)
+
+> Products 2 & 3 below are **one new project, separate from the macOS CLI repo** — its own
+> repo `dreamcleanr-server` (own releases, own README, own chatbot). It **shares the engine
+> philosophy** and the `snapshot → plan → confirm → apply → receipt` architecture; a shared
+> core can be extracted into a small library once both stabilize. v1 (getupsoft) and the
+> commercial SSH edition are sequential **phases of this one adjacent project**, not separate
+> codebases.
+
+## Product 2 — Server Edition v1 (Developer Server) — **GetUpSoft Ubuntu-first**
+
+Target v1: the operator's **Ubuntu server on GetUpSoft** (multi-tenant — the operator's
+projects *and* other people's run here). The defining requirement, in the operator's words:
+*"assign areas not to touch… focus on where my projects are hosted, leave the other guys'
+projects alone — a recon then selection capability, to focus in on a zone."*
+
+### The core flow: Recon → Select → Scoped Reclaim
+
+**Phase A — RECON (read-only topology map).** Discover, attribute, never touch:
+- processes (RSS/CPU/owner), `systemd` services, listening ports;
+- Docker/Podman: containers (running/idle/stopped), images (dangling/unused), volumes,
+  networks, **compose project labels** (`com.docker.compose.project`) and owners;
+- disk by path & owner (`du` parallelized), RAM by process/cgroup, swap pressure;
+- "who owns what": map paths/containers/services → tenant (by user, dir prefix, compose
+  project, or label). Output a **topology report** the operator reviews.
+- **Unattributed is a top-line recon section.** Raw `docker run` containers (no compose
+  label), `root`-owned processes, files under shared dirs — surface these prominently so the
+  operator resolves attribution *before* zoning. Unknown = untouchable (denylist-first), but
+  it must be loud, not silently skipped.
+
+**Phase B — ZONE SELECTION (the safety core).** Operator assigns scope explicitly:
+- **Include zones** (e.g. `/srv/jlfg/**`, compose projects `leadgen|mymca|merchantpulse`,
+  user `jlfg`) and **exclude zones** (everything else — *other tenants*).
+- **Denylist-first invariant:** anything not in an include zone is untouchable. This is the
+  server analog of macOS protected-state — the one rule that can never be violated.
+- Zones persist in a config (`/etc/dreamcleanr/zones.yaml` or `~/.dreamcleanr/zones.yaml`),
+  versioned, with a `recon → propose zones → operator confirms` bootstrap.
+
+**Phase C — SCOPED RECLAIM (within the selected zone only, dry-run default, confirm to apply).**
+Every action must be *scope-able per target* — system-wide commands are banned (they hit
+other tenants):
+- **Containers/compute:** stop idle in-zone containers — *idle ≠ low CPU* on a server (a web
+  server is 0% between requests). Detect idle via **no open listener ports + no recent
+  request-log activity + operator-tagged `ephemeral: true`** in the zone config. `docker prune`
+  only with `--filter label=com.docker.compose.project=<in-zone>` (never bare). Remove
+  dangling images/volumes *owned by in-zone projects only*. Reversible (stop≠remove; re-pull).
+- **RAM/allocation efficiency:** flag over-provisioned mem/CPU `limits/reservations` in-zone;
+  **recommend rightsizing, never auto-apply.**
+- **Disk:** in-zone build/CI-runner caches (work dirs + action caches + Docker layer caches —
+  **the highest-yield win on getupsoft's self-hosted runners**), in-zone `~/.cache`, rotated
+  app logs. **journald only per in-zone unit** (`--vacuum-size --unit=<unit>`), never global.
+  **Package caches (apt/pip system) are host-level** — separate explicit confirmation, never
+  folded into a zone run (they're shared across tenants).
+- **Database storage (surface-only):** Postgres/Supabase WAL bloat, dead tuples, unused
+  indexes — **recommend** operator-run `VACUUM`/`REINDEX`; **never auto-VACUUM.** High value
+  for the JLFG stack, zero risk while advisory.
+- **Process hygiene:** zombie reap (signal parent), stale in-zone helpers.
+- **Topology efficiency report:** idle services, duplicate stacks, consolidation candidates,
+  "reclaimable RAM/compute/disk in <zone>" — the same named-source ceiling, server-scale.
+
+### Architecture (v1, lightweight)
+- Python, stdlib-first; runs **on** getupsoft (over Tailscale/SSH). One-shot CLI first
+  (`dreamcleanr-server recon` / `select` / `clean --zone <z>`), reusing the macOS engine's
+  classification/ceiling/reversibility patterns. Docker via CLI/socket; systemd via `systemctl`.
+- Reuses: snapshot→plan→confirm→apply→receipt; the named ceiling; quarantine/Trash analog
+  (`docker stop` and a staging dir for files); the dry-run-default + confirm gate.
+- Later: agent/daemon + scheduled "guardian"; multi-host fleet dashboard.
+
+### Safety invariants (server)
+- **Zone isolation is a code-level kill switch, not prose.** Every `apply` path takes a zone
+  object and asserts `target ∈ zone.include AND target ∉ zone.exclude` before *any* subprocess.
+  A CI test — *"given zones X/Y, no action targets outside X"* — gates every release.
+- **Linux has no Trash → reversibility = snapshots.** Before any destructive action, verify a
+  recent filesystem/backup snapshot exists (ZFS/Btrfs/Restic/Borg); refuse or loudly warn if
+  not. That's the honest server reversibility story.
+- Dry-run default; explicit `--apply` + confirm; reversible-first (stop≠remove).
+- Never stop a serving container/service (idle = no listener + no recent requests + operator
+  `ephemeral` tag + confirm + operator sees the named list first).
+- Never touch other tenants' data, ever — the catastrophic regression to design out.
+
+### Monetization (Server Edition is the recurring-revenue play)
+- Servers accrue cruft *continuously* → genuine recurring value (unlike one-time desktop cleanup).
+- Tiers: per-server one-time (parity w/ desktop Pro) → **per-node Guardian subscription**
+  (scheduled scoped reclaim + RAM/disk-pressure alerts) → **fleet dashboard** (multi-host
+  topology + reclaim across a cluster) → Enterprise (policy, RBAC, audit).
+- Wow/viral asset: *"DreamCleanr Server reclaimed 38 GB RAM and 210 GB disk in zone `jlfg`
+  — and didn't touch the other 6 tenants."* Named sources + zone-safety = the trust+wow combo.
+
+---
+
+---
+
+## Product 3 — DreamCleanr Server (Commercial) — server-agnostic, multi-host, **over SSH**
+
+After the getupsoft v1 proves the engine, productize it to run across *any* self-hosted
+server — **agentless, over SSH** (Ansible-style: connect, run the recon/reclaim engine
+remotely, collect the receipt; nothing to install on the target → "lightweight, download
+only if needed" carries over).
+
+- **Architecture:** an inventory of hosts (SSH targets, jump hosts, Tailscale ok); push the
+  stdlib engine over SSH (or run via a transient venv), execute recon/plan/apply remotely,
+  stream named-source receipts back. Per-host zones; fleet view aggregates.
+- **Trust model changes sharply once it's a product** (v1 getupsoft = single trusted operator;
+  commercial = many operators/servers): the **zone config becomes an attack surface** (a
+  malicious/erroneous config could target the wrong paths). Required from day one of the
+  commercial tier: **signed zone configs, RBAC, full audit log of every action, least-priv SSH
+  (dedicated key, no root unless a step needs it + justified), and a hard dry-run-first gate.**
+- **Reuse:** the same engine, ceiling, denylist-first kill switch, snapshot-reversibility check
+  — now executed remotely per host.
+- **Monetization:** per-node Guardian subscription + fleet dashboard (this is the recurring,
+  scalable revenue — cruft accrues on every server continuously).
+
+## Go-to-Market — riding the self-hosted resurgence (sysadmin-grade)
+
+The self-hosted comeback is a **trust** resurgence (control over cost / data / deplatforming),
+not a cleaner resurgence. So lead with **safety, not cleanup**: every infra tool says "we make
+it easy" — DreamCleanr Server says **"we make it safe to clean what's already yours."** Different
+category. Vocabulary: *survey, attribute, scope, reclaim, attest* — not clean/free/boost (that's
+CleanMyMac's lexicon). Position as a **hygiene companion for your self-hosted stack.**
+
+**The receipt is the marketing.** Dogfood it: a post — *"What I reclaimed on my own getupsoft
+box, and what I refused to touch"* — with the real receipt (named sources, the unattributed
+section, the zones config, the snapshot check) beats any landing copy. r/selfhosted reads
+receipts, not slogans.
+
+**Moves, in payoff order:**
+1. **Recon-only free tier, forever.** Read-only `recon` = zero-risk wedge; every recon is a
+   qualified install; self-discovery of unattributed cruft is the hook to paid scoped reclaim.
+2. **The differentiated receipt line:** *"Reclaimed X GB in zone `jlfg`. Other tenants (6):
+   untouched. Snapshot verified before apply."* `apt autoremove` / CleanMyMac cannot say this.
+3. **Channels in order:** r/selfhosted → lobste.rs → Hacker News — dogfood receipt + zones config
+   + source link; no corporate marketing.
+4. **Distribute through the toolchain they already run:** Coolify (highest momentum now),
+   Yunohost, Cosmos, Dokploy — a post-deploy hook running recon weekly + posting the receipt to
+   Discord/Matrix beats ten landing pages.
+5. **`docker-compose.dreamcleanr.yml` one-liner:** paste, set `ZONE_INCLUDE`, `up`, get a receipt.
+6. **Weekly "Server Hygiene Report" email** (first free): the recurring lever — debt visibly
+   accrues week-over-week; subscribers pay to stop watching it grow.
+
+**Refuse (on brand):** no GB leaderboards/gamification; no telemetry by default (zero-network
+carries from macOS); no auto-update on apply (pin versions, operator upgrades); no "we'll fix it
+for you" (recommendations only on rightsizing/indexes/journald — the operator is the operator).
+
+**Pricing nuance (self-hosted ICP):** they pay one-time for *a CLI they run*, monthly for *a
+service that runs on their behalf.* So the **recurring product is the managed/scheduled Guardian +
+weekly receipt** — never the CLI itself (they'll mirror a CLI from GitHub).
+
+**Threat model to spell out** (sysadmins read these, not marketing): *"compromised SSH key signs a
+malicious zone config"* → defended by signed configs + per-host audit log + dry-run-first +
+snapshot-verification gate + the denylist-first scope assertion. Even a bad config can't act
+without the operator confirming a named, scope-asserted plan.
+
+**Receipt format = share mechanic (build day one):** top-line **"Untouched zones (N)"** and
+**"Snapshot verified: yes/no"**, plus a `--report-format markdown` flag so the receipt pastes
+straight into a Reddit comment or GitHub issue.
+
+**Positioning lines (each backed by an engine behavior):**
+- "Recon-first. Zone-scoped. Reversible. The cleaner that refuses to touch what isn't yours."
+- "Self-hosted is freedom. DreamCleanr Server is the hygiene that keeps it that way."
+- "Your `docker system prune` doesn't know which compose project is yours. We do."
+- "It checks for a snapshot before it runs the destructive step. Because you would."
+
+## Sequencing
+1. Land the open macOS PR (#30).
+2. **MEM-ACT** (macOS memory verbs — `ollama stop`, idle-container stop).
+3. **Server Edition RECON (read-only) on getupsoft — start right after MEM-ACT.** Recon is the
+   longest-lead-time learning (topology map + attribution edge cases inform everything). Build
+   macOS advanced file cleanup (DerivedData/dead-deps) **in parallel** — they don't conflict.
+4. Server Edition v1: zone-select → scoped reclaim MVP (getupsoft, trusted single-operator).
+5. **Product 3 — commercial server-agnostic over SSH** (adds signing/RBAC/audit/fleet).
+6. Guardian (scheduled) across editions; menu-bar GUI; MODEL-2.
+
+## Honesty hazards to design out (so marketing never overpromises)
+- Zombies are hygiene, not a RAM win. · Inactive RAM isn't reclaimable. · Rightsizing is a
+  recommendation, not an auto-edit. · Server reclaim must be zone-locked — "we cleaned the
+  server" without "only your zone" is the trust-killer. · Every claim maps to an engine
+  function (keep the claim↔engine table per product).

--- a/dreamcleanr/cli.py
+++ b/dreamcleanr/cli.py
@@ -14,12 +14,39 @@ from .core import (
     build_cleanup_report,
     capture_snapshot,
     default_report_dir,
+    human_bytes,
     plan_cleanup,
     apply_actions,
     now_iso,
     prune_history_files,
     prune_rotated_logs,
 )
+
+
+def _planned_deletions(actions: list) -> list:
+    """Actions that would actually delete/terminate (not preview-gated)."""
+    return [a for a in actions if a.details.get("apply_allowed", True)]
+
+
+def _confirm_apply(actions: list, mode: str) -> bool:
+    deletions = _planned_deletions(actions)
+    paths = [a for a in deletions if a.target_type != "process"]
+    procs = sum(1 for a in deletions if a.target_type == "process")
+    total = sum(a.bytes_reclaimed for a in paths)
+    print(f"DreamCleanr will apply {len(deletions)} action(s) in '{mode}' mode:")
+    for action in paths[:20]:
+        label = action.details.get("label", action.target)
+        print(f"  delete     {label}  (~{human_bytes(action.bytes_reclaimed)})")
+    if len(paths) > 20:
+        print(f"  … and {len(paths) - 20} more path(s)")
+    if procs:
+        print(f"  terminate  {procs} stale process(es)")
+    print(f"Estimated reclaim: ~{human_bytes(total)}")
+    try:
+        answer = input("Proceed? [y/N] ").strip().lower()
+    except EOFError:
+        return False
+    return answer in {"y", "yes"}
 from .reporting import build_receipt_summary, build_team_export, write_html, write_team_csv
 from .scheduler import install_launch_agent, uninstall_launch_agent, write_launch_agent
 
@@ -101,6 +128,18 @@ def command_clean(args: argparse.Namespace) -> int:
             planned_actions = [action for action in planned_actions if action.target_type == "process"]
         elif args.scope == "storage":
             planned_actions = [action for action in planned_actions if action.target_type != "process"]
+
+        if not dry_run and _planned_deletions(planned_actions):
+            if not getattr(args, "yes", False):
+                if not sys.stdin.isatty():
+                    print(
+                        "Refusing to --apply in a non-interactive session without --yes.",
+                        file=sys.stderr,
+                    )
+                    return 2
+                if not _confirm_apply(planned_actions, args.mode):
+                    print("Aborted — running a preview instead; no changes made.")
+                    dry_run = True
         actions = apply_actions(before, planned_actions, dry_run=dry_run)
         after = capture_snapshot(mode=args.mode)
         report = build_cleanup_report(before, after, actions, mode=args.mode, dry_run=dry_run)
@@ -206,6 +245,7 @@ def build_parser() -> argparse.ArgumentParser:
     clean.add_argument("--mode", choices=["safe", "balanced", "max"], default="balanced")
     clean.add_argument("--scope", choices=["all", "processes", "storage"], default="all")
     clean.add_argument("--apply", action="store_true", help="Apply cleanup actions instead of dry-run preview.")
+    clean.add_argument("--yes", "-y", action="store_true", help="Skip the confirmation prompt (required for non-interactive --apply, e.g. the scheduled job).")
     clean.add_argument("--output-dir", help="Directory for JSON and HTML reports.")
     clean.add_argument("--json-out", help="Write cleanup report JSON to a specific file.")
     clean.add_argument("--html-out", help="Write cleanup report HTML to a specific file.")

--- a/dreamcleanr/cli.py
+++ b/dreamcleanr/cli.py
@@ -21,7 +21,25 @@ from .core import (
     now_iso,
     prune_history_files,
     prune_rotated_logs,
+    reclaim_ceiling,
 )
+
+
+def _print_ceiling(snapshot: Dict[str, Any], stream) -> None:
+    try:
+        ceiling = reclaim_ceiling(snapshot)
+    except Exception:  # display is non-critical — never let it break a cleanup run
+        return
+    print(
+        f"DreamCleanr can reclaim up to {human_bytes(ceiling['ram_bytes'])} RAM "
+        f"and {human_bytes(ceiling['disk_bytes'])} disk right now.",
+        file=stream,
+    )
+    for source in ceiling["ram_sources"][:5]:
+        tag = "  (reversible)" if source.get("reversible") else ""
+        print(f"  RAM   {source['source']}  ~{human_bytes(source['bytes'])}  → {source['action']}{tag}", file=stream)
+    for source in ceiling["disk_sources"][:3]:
+        print(f"  disk  {source['source']}  ~{human_bytes(source['bytes'])}", file=stream)
 
 
 def _planned_deletions(actions: list) -> list:
@@ -107,6 +125,7 @@ def _failure_payload(exc: Exception, mode: str, dry_run: bool) -> Dict[str, Any]
 
 def command_scan(args: argparse.Namespace) -> int:
     snapshot = capture_snapshot(mode=args.mode)
+    _print_ceiling(snapshot, sys.stderr)  # human summary on stderr; stdout stays pure JSON
     payload = snapshot
     if args.json_out:
         _write_json(Path(args.json_out), payload)
@@ -157,6 +176,7 @@ def command_clean(args: argparse.Namespace) -> int:
 
     try:
         before = capture_snapshot(mode=args.mode)
+        _print_ceiling(before, sys.stdout)  # lead with the wow number
         planned_actions = plan_cleanup(before, mode=args.mode)
         if args.scope == "processes":
             planned_actions = [action for action in planned_actions if action.target_type == "process"]

--- a/dreamcleanr/cli.py
+++ b/dreamcleanr/cli.py
@@ -49,11 +49,15 @@ def _planned_deletions(actions: list) -> list:
 
 def _confirm_apply(actions: list, mode: str, use_trash: bool = False) -> bool:
     deletions = _planned_deletions(actions)
-    paths = [a for a in deletions if a.target_type != "process"]
+    mem = [a for a in deletions if a.target_type == "memory"]
+    paths = [a for a in deletions if a.target_type not in {"process", "memory"}]
     procs = sum(1 for a in deletions if a.target_type == "process")
-    total = sum(a.bytes_reclaimed for a in paths)
+    disk_total = sum(a.bytes_reclaimed for a in paths)
+    ram_total = sum(a.bytes_reclaimed for a in mem)
     verb = "trash" if use_trash else "delete"
     print(f"DreamCleanr will apply {len(deletions)} action(s) in '{mode}' mode:")
+    for action in mem[:10]:
+        print(f"  unload    {action.target}  (~{human_bytes(action.bytes_reclaimed)} RAM)  (reversible)")
     for action in paths[:20]:
         label = action.details.get("label", action.target)
         print(f"  {verb:<9} {label}  (~{human_bytes(action.bytes_reclaimed)})")
@@ -63,7 +67,10 @@ def _confirm_apply(actions: list, mode: str, use_trash: bool = False) -> bool:
         print(f"  terminate {procs} stale process(es)")
     if use_trash:
         print("Paths go to the macOS Trash (restore from Finder); empty the Trash to reclaim space.")
-    print(f"Estimated reclaim: ~{human_bytes(total)}")
+    reclaim = f"~{human_bytes(disk_total)} disk"
+    if ram_total:
+        reclaim += f" + ~{human_bytes(ram_total)} RAM"
+    print(f"Estimated reclaim: {reclaim}")
     try:
         answer = input("Proceed? [y/N] ").strip().lower()
     except EOFError:

--- a/dreamcleanr/cli.py
+++ b/dreamcleanr/cli.py
@@ -25,6 +25,18 @@ from .core import (
 )
 
 
+def _actions_caused_state_change(actions) -> bool:
+    """True if any action mutated host state (deleted disk / terminated proc /
+    unloaded model). Per issue #8 — skip the duplicate-snapshot rescan when
+    nothing happened.
+
+    Excludes: planned (dry-run), kept (preview-only), blocked, failed,
+    missing, skipped — none of those touched disk or RAM.
+    """
+    successful = {"deleted", "terminated", "unloaded"}
+    return any(action.result in successful for action in actions)
+
+
 def _print_ceiling(snapshot: Dict[str, Any], stream) -> None:
     try:
         ceiling = reclaim_ceiling(snapshot)
@@ -202,7 +214,19 @@ def command_clean(args: argparse.Namespace) -> int:
                     print("Aborted — running a preview instead; no changes made.")
                     dry_run = True
         actions = apply_actions(before, planned_actions, dry_run=dry_run, trash=use_trash)
-        after = capture_snapshot(mode=args.mode)
+
+        # Issue #8: skip the duplicate-snapshot cost when nothing actually
+        # changed. In dry-run mode AND when no action mutated state
+        # (all blocked/failed/skipped/kept), the after snapshot would be
+        # identical to before — re-use it and stamp a fresh finished_at.
+        # Saves ~half the wall-clock time on dry-run flows (the second
+        # capture_snapshot is the largest single cost per profiling on
+        # issue #8: balanced scan ~29s, full apply path ~56s).
+        if dry_run or not _actions_caused_state_change(actions):
+            after = dict(before)
+            after["finished_at"] = now_iso()
+        else:
+            after = capture_snapshot(mode=args.mode)
         report = build_cleanup_report(before, after, actions, mode=args.mode, dry_run=dry_run)
         report_dict = report.to_dict()
 

--- a/dreamcleanr/cli.py
+++ b/dreamcleanr/cli.py
@@ -130,13 +130,10 @@ def command_clean(args: argparse.Namespace) -> int:
             planned_actions = [action for action in planned_actions if action.target_type != "process"]
 
         if not dry_run and _planned_deletions(planned_actions):
-            if not getattr(args, "yes", False):
-                if not sys.stdin.isatty():
-                    print(
-                        "Refusing to --apply in a non-interactive session without --yes.",
-                        file=sys.stderr,
-                    )
-                    return 2
+            # Interactive runs confirm before deleting. Scripted / scheduled runs
+            # (no TTY) are intentional automation and proceed — this preserves an
+            # already-installed LaunchAgent. --yes skips the prompt explicitly.
+            if not getattr(args, "yes", False) and sys.stdin.isatty():
                 if not _confirm_apply(planned_actions, args.mode):
                     print("Aborted — running a preview instead; no changes made.")
                     dry_run = True
@@ -245,7 +242,7 @@ def build_parser() -> argparse.ArgumentParser:
     clean.add_argument("--mode", choices=["safe", "balanced", "max"], default="balanced")
     clean.add_argument("--scope", choices=["all", "processes", "storage"], default="all")
     clean.add_argument("--apply", action="store_true", help="Apply cleanup actions instead of dry-run preview.")
-    clean.add_argument("--yes", "-y", action="store_true", help="Skip the confirmation prompt (required for non-interactive --apply, e.g. the scheduled job).")
+    clean.add_argument("--yes", "-y", action="store_true", help="Skip the interactive confirmation prompt before --apply.")
     clean.add_argument("--output-dir", help="Directory for JSON and HTML reports.")
     clean.add_argument("--json-out", help="Write cleanup report JSON to a specific file.")
     clean.add_argument("--html-out", help="Write cleanup report HTML to a specific file.")

--- a/dreamcleanr/cli.py
+++ b/dreamcleanr/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import sys
 import traceback
@@ -47,6 +48,26 @@ def _confirm_apply(actions: list, mode: str) -> bool:
     except EOFError:
         return False
     return answer in {"y", "yes"}
+
+
+def _acquire_run_lock(output_dir: Path):
+    """Non-blocking exclusive lock so a manual run and the scheduled job don't
+    apply concurrently to the same report dir. Returns the held handle or None."""
+    lock_path = output_dir / ".dreamcleanr.lock"
+    handle = open(lock_path, "w")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        handle.close()
+        return None
+    return handle
+
+
+def _release_run_lock(handle) -> None:
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    finally:
+        handle.close()
 from .reporting import build_receipt_summary, build_team_export, write_html, write_team_csv
 from .scheduler import install_launch_agent, uninstall_launch_agent, write_launch_agent
 
@@ -121,6 +142,16 @@ def command_clean(args: argparse.Namespace) -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
     latest = _latest_paths(output_dir)
 
+    lock_handle = None
+    if not dry_run:
+        lock_handle = _acquire_run_lock(output_dir)
+        if lock_handle is None:
+            print(
+                "Another DreamCleanr apply is in progress for this report dir; skipping.",
+                file=sys.stderr,
+            )
+            return 0
+
     try:
         before = capture_snapshot(mode=args.mode)
         planned_actions = plan_cleanup(before, mode=args.mode)
@@ -189,6 +220,9 @@ def command_clean(args: argparse.Namespace) -> int:
         print(f"DreamCleanr clean failed: {exc}", file=sys.stderr)
         print(f"Failure report: {failure_path}", file=sys.stderr)
         return 1
+    finally:
+        if lock_handle is not None:
+            _release_run_lock(lock_handle)
 
 
 def command_schedule_install(args: argparse.Namespace) -> int:

--- a/dreamcleanr/cli.py
+++ b/dreamcleanr/cli.py
@@ -29,19 +29,22 @@ def _planned_deletions(actions: list) -> list:
     return [a for a in actions if a.details.get("apply_allowed", True)]
 
 
-def _confirm_apply(actions: list, mode: str) -> bool:
+def _confirm_apply(actions: list, mode: str, use_trash: bool = False) -> bool:
     deletions = _planned_deletions(actions)
     paths = [a for a in deletions if a.target_type != "process"]
     procs = sum(1 for a in deletions if a.target_type == "process")
     total = sum(a.bytes_reclaimed for a in paths)
+    verb = "trash" if use_trash else "delete"
     print(f"DreamCleanr will apply {len(deletions)} action(s) in '{mode}' mode:")
     for action in paths[:20]:
         label = action.details.get("label", action.target)
-        print(f"  delete     {label}  (~{human_bytes(action.bytes_reclaimed)})")
+        print(f"  {verb:<9} {label}  (~{human_bytes(action.bytes_reclaimed)})")
     if len(paths) > 20:
         print(f"  … and {len(paths) - 20} more path(s)")
     if procs:
-        print(f"  terminate  {procs} stale process(es)")
+        print(f"  terminate {procs} stale process(es)")
+    if use_trash:
+        print("Paths go to the macOS Trash (restore from Finder); empty the Trash to reclaim space.")
     print(f"Estimated reclaim: ~{human_bytes(total)}")
     try:
         answer = input("Proceed? [y/N] ").strip().lower()
@@ -160,15 +163,18 @@ def command_clean(args: argparse.Namespace) -> int:
         elif args.scope == "storage":
             planned_actions = [action for action in planned_actions if action.target_type != "process"]
 
+        # Trash (restorable) vs hard-delete. Default: on for the aggressive max
+        # tier, off for balanced (regenerable caches free space immediately).
+        use_trash = args.trash if getattr(args, "trash", None) is not None else (args.mode == "max")
         if not dry_run and _planned_deletions(planned_actions):
             # Interactive runs confirm before deleting. Scripted / scheduled runs
             # (no TTY) are intentional automation and proceed — this preserves an
             # already-installed LaunchAgent. --yes skips the prompt explicitly.
             if not getattr(args, "yes", False) and sys.stdin.isatty():
-                if not _confirm_apply(planned_actions, args.mode):
+                if not _confirm_apply(planned_actions, args.mode, use_trash):
                     print("Aborted — running a preview instead; no changes made.")
                     dry_run = True
-        actions = apply_actions(before, planned_actions, dry_run=dry_run)
+        actions = apply_actions(before, planned_actions, dry_run=dry_run, trash=use_trash)
         after = capture_snapshot(mode=args.mode)
         report = build_cleanup_report(before, after, actions, mode=args.mode, dry_run=dry_run)
         report_dict = report.to_dict()
@@ -277,6 +283,8 @@ def build_parser() -> argparse.ArgumentParser:
     clean.add_argument("--scope", choices=["all", "processes", "storage"], default="all")
     clean.add_argument("--apply", action="store_true", help="Apply cleanup actions instead of dry-run preview.")
     clean.add_argument("--yes", "-y", action="store_true", help="Skip the interactive confirmation prompt before --apply.")
+    clean.add_argument("--trash", dest="trash", action="store_true", default=None, help="Move deleted items to the macOS Trash (restorable) instead of removing them. Default: on for --mode max.")
+    clean.add_argument("--no-trash", dest="trash", action="store_false", help="Hard-delete to reclaim space immediately, even in --mode max.")
     clean.add_argument("--output-dir", help="Directory for JSON and HTML reports.")
     clean.add_argument("--json-out", help="Write cleanup report JSON to a specific file.")
     clean.add_argument("--html-out", help="Write cleanup report HTML to a specific file.")

--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -577,6 +577,54 @@ def classify_process_role(record: ProcessRecord) -> None:
         record.role = "probe"
         return
 
+    # Cross-product crashpad handlers + autoupdaters that don't belong to a
+    # known AI-dev product family. Classifying these in their own family
+    # keeps them eligible for stale-helper detection without misattributing
+    # them to claude/codex/docker. Per issue #1 — updater + crashpad coverage.
+    if (
+        ("crashpad_handler" in args or "crashpad-handler" in args)
+        and not any(t in args for t in ("/applications/claude.app/", "/applications/codex.app/",
+                                        "anthropic.claude-code", "openai.chatgpt-", "com.openai.codex"))
+    ):
+        record.family = "crashpad"
+        record.role = "crashpad"
+        return
+    if has_any_token(
+        args,
+        (
+            "/sparkle ",
+            "sparkle.app/contents",
+            "softwareupdate ",
+            "shipit ",
+            " shipit",
+            "/microsoft autoupdate/",
+            "msupdate",
+            "homebrew autoupdate",
+            "brew autoupdate",
+            "/google software update.app/",
+            "googlesoftwareupdate",
+        ),
+    ):
+        record.family = "updater"
+        # Order: more-specific brands first; `softwareupdate` substring
+        # is shared by macOS softwareupdate AND GoogleSoftwareUpdate, so
+        # google must be checked before the generic match.
+        if "google" in args:
+            record.role = "google_software_update"
+        elif "microsoft" in args or "msupdate" in args:
+            record.role = "msupdate"
+        elif "brew" in args or "homebrew" in args:
+            record.role = "brew_autoupdate"
+        elif "shipit" in args:
+            record.role = "shipit"
+        elif "sparkle" in args:
+            record.role = "sparkle"
+        elif "softwareupdate" in args:
+            record.role = "macos_softwareupdate"
+        else:
+            record.role = "generic_updater"
+        return
+
     if has_any_token(
         args,
         (
@@ -623,7 +671,10 @@ def classify_process_role(record: ProcessRecord) -> None:
             "/resources/codex app-server",
             "openai.chatgpt-",
             "com.openai.codex",
-            "crashpad_handler",
+            # Note: crashpad_handler removed as a generic trigger here per
+            # issue #1 — generic crashpads belong in the 'crashpad' family,
+            # codex-bundled crashpads still match via 'codex helper' or the
+            # codex.app/ paths and get role=crashpad below.
         ),
     ):
         record.family = "codex"
@@ -652,7 +703,10 @@ def classify_process_role(record: ProcessRecord) -> None:
             "/resources/native-binary/claude",
             "claude --output-format",
             "--mcp-config",
-            "crashpad_handler",
+            # Note: crashpad_handler removed as a generic trigger here per
+            # issue #1 — claude-bundled crashpads match via the claude.app
+            # path or 'claude helper' below; generic crashpads land in
+            # the 'crashpad' family.
         ),
     ):
         record.family = "claude"
@@ -686,16 +740,23 @@ _STRONG_ROLES: Dict[str, frozenset] = {
     "docker": frozenset({"vmnetd", "backend", "backend_service", "virtualization", "sandbox", "docker_helper"}),
     "claude": frozenset({"claude_app", "vscode_cli"}),
     "codex": frozenset({"codex_app", "helper", "renderer", "cli_service"}),
+    "crashpad": frozenset(),  # crashpad is never "strong" — it's always a helper
+    "updater": frozenset(),   # updaters are never "strong" primary
 }
 _WEAK_ROLES: Dict[str, frozenset] = {
     "docker": frozenset({"docker_cli", "docker_cli_probe", "shell_docker_probe", "shell_docker_session"}),
     "claude": frozenset({"shipit", "crashpad"}),
     "codex": frozenset({"updater", "crashpad"}),
+    "crashpad": frozenset({"crashpad"}),
+    "updater": frozenset({"sparkle", "macos_softwareupdate", "shipit", "msupdate", "brew_autoupdate",
+                           "google_software_update", "generic_updater"}),
 }
 _PRIMARY_ROLES: Dict[str, frozenset] = {
     "docker": frozenset({"vmnetd", "backend", "virtualization"}),
     "claude": frozenset({"claude_app", "vscode_cli"}),
     "codex": frozenset({"codex_app", "cli_service"}),
+    "crashpad": frozenset(),  # crashpad is never primary
+    "updater": frozenset(),   # autoupdaters are not "active primary" — they're transient
 }
 # Flat union used by classify_processes; derived from _PRIMARY_ROLES so both stay in sync.
 _PRIMARY_ROLES_FLAT: frozenset = frozenset().union(*_PRIMARY_ROLES.values())

--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -1252,6 +1252,31 @@ def terminate_process(pid: int) -> bool:
     return False
 
 
+def process_args(pid: int) -> Optional[str]:
+    """Current argument string for a live PID, or None if it no longer exists."""
+    result = run_command(["ps", "-p", str(pid), "-o", "args="], timeout=3)
+    if not result["ok"]:
+        return None
+    text = result["stdout"].strip()
+    return text or None
+
+
+def process_family(pid: int) -> Optional[str]:
+    """Re-classify a live PID's family now, to guard against PID reuse.
+
+    Returns None if the PID no longer exists.
+    """
+    args = process_args(pid)
+    if args is None:
+        return None
+    record = ProcessRecord(
+        pid=pid, ppid=0, etime="", elapsed_seconds=0,
+        cpu_percent=0.0, mem_percent=0.0, rss_kb=0, command="", args=args,
+    )
+    classify_process_role(record)
+    return record.family
+
+
 def apply_actions(
     snapshot: Dict[str, Any],
     actions: List[CleanupAction],
@@ -1274,10 +1299,23 @@ def apply_actions(
                 continue
             if action.target_type == "process":
                 pid = int(action.target)
-                success = terminate_process(pid)
-                realized.result = "terminated" if success else "blocked"
-                if not success:
-                    realized.reason = "Process could not be terminated safely."
+                # Guard against PID reuse between scan and apply: confirm the PID
+                # still belongs to the family we classified before sending a signal.
+                current_family = process_family(pid)
+                if current_family is None:
+                    realized.result = "terminated"
+                    realized.reason = "Process already exited before apply."
+                elif current_family != action.family:
+                    realized.result = "blocked"
+                    realized.reason = (
+                        f"PID {pid} now classifies as '{current_family}', not "
+                        f"'{action.family}' — likely reused; not terminated."
+                    )
+                else:
+                    success = terminate_process(pid)
+                    realized.result = "terminated" if success else "blocked"
+                    if not success:
+                        realized.reason = "Process could not be terminated safely."
             elif action.target_type == "path":
                 path = Path(action.target)
                 if action.target.endswith("Library/Caches"):

--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -1212,13 +1212,39 @@ def plan_cleanup(snapshot: Dict[str, Any], mode: str = "balanced") -> List[Clean
     return actions
 
 
-def path_delete(path: Path) -> None:
+def _trash_dir() -> Path:
+    return Path.home() / ".Trash"
+
+
+def trash_path(path: Path) -> Optional[Path]:
+    """Move a path into the macOS Trash (restorable via Finder). On the same
+    volume this is a fast rename, not a copy. Returns the destination or None."""
+    trash_dir = _trash_dir()
+    try:
+        trash_dir.mkdir(exist_ok=True)
+    except OSError:
+        return None
+    dest = trash_dir / path.name
+    if dest.exists():
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        dest = trash_dir / f"{path.name}.{stamp}-{uuid.uuid4().hex[:6]}"
+    shutil.move(str(path), str(dest))
+    return dest
+
+
+def path_delete(path: Path, trash: bool = False) -> None:
     # Remove a symlink itself rather than following it — never traverse out of
     # the intended tree (and avoid shutil.rmtree raising on a symlinked dir).
     if path.is_symlink():
-        path.unlink(missing_ok=True)
+        if trash:
+            trash_path(path)
+        else:
+            path.unlink(missing_ok=True)
         return
     if not path.exists():
+        return
+    if trash:
+        trash_path(path)
         return
     if path.is_dir():
         shutil.rmtree(path)
@@ -1250,7 +1276,7 @@ def prune_rotated_logs(output_dir: Path, keep: int = DEFAULT_LOG_RETENTION_COUNT
     return removed
 
 
-def remove_unprotected_library_caches(protected_basenames: List[str]) -> int:
+def remove_unprotected_library_caches(protected_basenames: List[str], trash: bool = False) -> int:
     cache_root = SAFE_CACHE_PATHS["library_caches"]
     if not cache_root.exists():
         return 0
@@ -1259,7 +1285,7 @@ def remove_unprotected_library_caches(protected_basenames: List[str]) -> int:
         if child.name in protected_basenames:
             continue
         reclaimed += du_bytes(child)
-        path_delete(child)
+        path_delete(child, trash=trash)
     return reclaimed
 
 
@@ -1318,6 +1344,7 @@ def apply_actions(
     snapshot: Dict[str, Any],
     actions: List[CleanupAction],
     dry_run: bool,
+    trash: bool = False,
 ) -> List[CleanupAction]:
     protected_caches = protected_library_cache_basenames(snapshot)
     applied: List[CleanupAction] = []
@@ -1356,14 +1383,16 @@ def apply_actions(
             elif action.target_type == "path":
                 path = Path(action.target)
                 if action.target.endswith("Library/Caches"):
-                    realized.bytes_reclaimed = remove_unprotected_library_caches(protected_caches)
+                    realized.bytes_reclaimed = remove_unprotected_library_caches(protected_caches, trash=trash)
                     realized.result = "deleted"
                 elif path.exists():
                     realized.bytes_reclaimed = du_bytes(path)
-                    path_delete(path)
+                    path_delete(path, trash=trash)
                     realized.result = "deleted"
                 else:
                     realized.result = "missing"
+                if trash and realized.result == "deleted":
+                    realized.details["trashed"] = True
             elif action.target_type == "docker":
                 if snapshot["process_summary"]["docker"]["recommended_action"] != "docker_system_prune":
                     realized.result = "blocked"

--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -23,6 +23,15 @@ DEFAULT_LOG_RETENTION_COUNT = 5
 STALE_PROCESS_MIN_ELAPSED_SECONDS = 300
 STALE_PROCESS_MAX_CPU_PERCENT = 1.0
 
+# Smart-reclaim policy. Downloaded models are user assets (expensive to refetch),
+# never auto-deleted — surfaced for review only. Everything else is a regenerable
+# cache. RECLAIMABLE_CACHE_LABELS are the regenerable detector caches safe to
+# auto-clear in max: they live OUTSIDE ~/Library/Caches and are not in
+# SAFE_CACHE_PATHS, so they never overlap the wholesale sweep or other actions.
+STALE_DETECTOR_DAYS = 14
+MODEL_DATA_DETECTORS = {"huggingface", "ollama", "lm_studio", "git_lfs"}
+RECLAIMABLE_CACHE_LABELS = {"pip_cache", "pnpm_store", "library_pnpm_store", "yarn_cache"}
+
 PROTECTED_STATE_PATHS = {
     "codex_home": Path.home() / ".codex",
     "claude_home": Path.home() / ".claude",
@@ -299,6 +308,7 @@ def gather_detector_findings(home: Optional[Path] = None) -> List[Dict[str, Any]
     # together in parallel so big model dirs don't serialize the scan.
     per_detector: Dict[str, List[Tuple[str, Path]]] = {}
     all_paths: List[Path] = []
+    mtime_map: Dict[str, float] = {}
     for key, detector in registry.items():
         items: List[Tuple[str, Path]] = []
         seen_paths = set()
@@ -311,8 +321,13 @@ def gather_detector_findings(home: Optional[Path] = None) -> List[Dict[str, Any]
                 continue
             items.append((label, path))
             all_paths.append(path)
+            try:
+                mtime_map[normalized] = path.stat().st_mtime
+            except OSError:
+                pass
         per_detector[key] = items
     size_map = du_bytes_many(all_paths)
+    now = time.time()
 
     findings: List[DetectorFinding] = []
     for key, detector in registry.items():
@@ -330,6 +345,12 @@ def gather_detector_findings(home: Optional[Path] = None) -> List[Dict[str, Any]
             total_bytes += size_bytes
         if not observed_paths:
             continue
+        reclaim_policy = "model_data" if key in MODEL_DATA_DETECTORS else "regenerable"
+        reclaimable_bytes = sum(
+            item["size_bytes"] for item in observed_paths if item["label"] in RECLAIMABLE_CACHE_LABELS
+        )
+        mtimes = [mtime_map[item["path"]] for item in observed_paths if item["path"] in mtime_map]
+        last_touched_days = int((now - max(mtimes)) // 86400) if mtimes else None
         findings.append(
             DetectorFinding(
                 key=key,
@@ -340,6 +361,9 @@ def gather_detector_findings(home: Optional[Path] = None) -> List[Dict[str, Any]
                 cleanup_ready=detector["cleanup_ready"],
                 notes=detector["notes"],
                 observed_paths=observed_paths,
+                reclaim_policy=reclaim_policy,
+                last_touched_days=last_touched_days,
+                reclaimable_bytes=reclaimable_bytes,
             )
         )
     findings.sort(key=lambda item: item.total_bytes, reverse=True)
@@ -460,7 +484,22 @@ def annotate_detector_findings(
         item = dict(finding)
         item["active_project_roots"] = unique_roots[:5]
         item["active_project_count"] = len(unique_roots)
-        item["safety_state"] = "guarded_by_active_projects" if unique_roots else "visibility_only"
+        guarded = bool(unique_roots)
+        item["safety_state"] = "guarded_by_active_projects" if guarded else "visibility_only"
+        # Smart recommendation, and gate reclaim on the active-project guard.
+        if guarded:
+            item["reclaimable_bytes"] = 0
+        if item.get("reclaim_policy") == "model_data":
+            item["recommendation"] = (
+                "Review — downloaded models are expensive to refetch; prune unused ones "
+                "with the tool itself (e.g. `ollama rm`, `huggingface-cli delete-cache`)."
+            )
+        elif guarded:
+            item["recommendation"] = "Guarded — tied to an active project; left alone."
+        elif item.get("reclaimable_bytes", 0) > 0:
+            item["recommendation"] = "Regenerable cache — safe to clear in --mode max."
+        else:
+            item["recommendation"] = "Visibility only."
         annotated.append(item)
     return annotated
 
@@ -1103,6 +1142,16 @@ def family_summary_from_actions(
     return summary
 
 
+def _path_overlaps_any(candidate: Path, planned: Iterable[str]) -> bool:
+    """True if candidate equals, contains, or is contained by any planned path —
+    so two cleanup actions can't target overlapping trees (double-count/missing)."""
+    for planned_str in planned:
+        other = Path(planned_str)
+        if candidate == other or other in candidate.parents or candidate in other.parents:
+            return True
+    return False
+
+
 def plan_cleanup(snapshot: Dict[str, Any], mode: str = "balanced") -> List[CleanupAction]:
     """Plan cleanup actions for the requested tier.
 
@@ -1208,6 +1257,31 @@ def plan_cleanup(snapshot: Dict[str, Any], mode: str = "balanced") -> List[Clean
             for dirname in CODEX_SUPPORT_CACHE_DIRS:
                 path = PROTECTED_STATE_PATHS["codex_support"] / dirname
                 safe_delete_action(f"codex_support_cache:{dirname}", path, "codex", "Codex support cache while inactive.")
+
+        # Smart reclaim: stale, regenerable, unguarded detector caches that live
+        # outside ~/Library/Caches. Model data is never auto-deleted (review only).
+        planned_paths = {action.target for action in actions if action.target_type == "path"}
+        for finding in snapshot.get("detector_findings", []):
+            if finding.get("reclaim_policy") != "regenerable":
+                continue
+            if finding.get("safety_state") == "guarded_by_active_projects":
+                continue
+            touched = finding.get("last_touched_days")
+            if touched is None or touched < STALE_DETECTOR_DAYS:
+                continue
+            for observed in finding.get("observed_paths", []):
+                if observed.get("label") not in RECLAIMABLE_CACHE_LABELS:
+                    continue
+                candidate = observed.get("path", "")
+                if not candidate or _path_overlaps_any(Path(candidate), planned_paths):
+                    continue
+                safe_delete_action(
+                    f"{finding['key']}:{observed['label']}",
+                    Path(candidate),
+                    "system",
+                    f"Stale regenerable {finding['key']} cache (last touched {touched}d ago).",
+                )
+                planned_paths.add(candidate)
 
     return actions
 

--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -1067,29 +1067,29 @@ def family_summary_from_actions(
 
 
 def plan_cleanup(snapshot: Dict[str, Any], mode: str = "balanced") -> List[CleanupAction]:
+    """Plan cleanup actions for the requested tier.
+
+    Tiers (cleaning power is never removed — only re-characterized by tier):
+
+    * ``safe``     — previews the standard tier without deleting anything. Every
+                     action is marked ``apply_allowed=False`` so ``--apply`` is a
+                     no-op guarantee.
+    * ``balanced`` — the default. Standard, low-blast-radius reclaim: regenerable
+                     developer/tool caches, Docker prune, and stale-process trim.
+    * ``max``      — aggressive. Everything ``balanced`` does PLUS the broad
+                     ``~/Library/Caches`` sweep and inactive app support caches.
+
+    The wholesale ``~/Library/Caches`` sweep lived in ``balanced`` (and even ran
+    in ``safe``); it is now ``max``-only so the default and the unattended
+    scheduled run stay fast but conservative.
+    """
     actions: List[CleanupAction] = []
+    preview_only = mode == "safe"
+    applies = not preview_only
+
     processes = [ProcessRecord(**item) for item in snapshot["processes"]]
     for process in processes:
         if process.classification not in {"STALE_CLI", "STALE_HELPER"}:
-            continue
-        if mode == "safe":
-            actions.append(
-                CleanupAction(
-                    target=str(process.pid),
-                    target_type="process",
-                    family=process.family,
-                    classification=process.classification,
-                    result="planned",
-                    bytes_reclaimed=process.rss_kb * 1024,
-                    reason="Would terminate stale helper or CLI probe process in balanced or max mode.",
-                    details={
-                        "pid": process.pid,
-                        "args": process.args,
-                        "elapsed_seconds": process.elapsed_seconds,
-                        "apply_allowed": False,
-                    },
-                )
-            )
             continue
         actions.append(
             CleanupAction(
@@ -1099,17 +1099,21 @@ def plan_cleanup(snapshot: Dict[str, Any], mode: str = "balanced") -> List[Clean
                 classification=process.classification,
                 result="planned",
                 bytes_reclaimed=process.rss_kb * 1024,
-                reason="Stale helper or CLI probe process with low activity and no active parent chain.",
+                reason=(
+                    "Would terminate stale helper or CLI probe process; preview only in safe mode."
+                    if preview_only
+                    else "Stale helper or CLI probe process with low activity and no active parent chain."
+                ),
                 details={
                     "pid": process.pid,
                     "args": process.args,
                     "elapsed_seconds": process.elapsed_seconds,
-                    "apply_allowed": True,
+                    "apply_allowed": applies,
                 },
             )
         )
 
-    def safe_delete_action(label: str, path: Path, family: str, reason: str) -> None:
+    def safe_delete_action(label: str, path: Path, family: str, reason: str, apply_allowed: bool = True) -> None:
         actions.append(
             CleanupAction(
                 target=str(path),
@@ -1119,19 +1123,20 @@ def plan_cleanup(snapshot: Dict[str, Any], mode: str = "balanced") -> List[Clean
                 result="planned",
                 bytes_reclaimed=du_bytes(path),
                 reason=reason,
-                details={"label": label, "apply_allowed": True},
+                details={"label": label, "apply_allowed": apply_allowed},
             )
         )
 
-    safe_delete_action("uv_cache", SAFE_CACHE_PATHS["uv_cache"], "system", "Regenerable uv cache.")
-    safe_delete_action("trunk_cache", SAFE_CACHE_PATHS["trunk_cache"], "system", "Regenerable trunk cache.")
-    safe_delete_action("gradle_cache", SAFE_CACHE_PATHS["gradle_cache"], "system", "Regenerable Gradle cache.")
-    safe_delete_action("npm_cache", SAFE_CACHE_PATHS["npm_cache"], "system", "Regenerable npm cache.")
-    safe_delete_action("npx_cache", SAFE_CACHE_PATHS["npx_cache"], "system", "Regenerable npx cache.")
-    safe_delete_action("library_caches", SAFE_CACHE_PATHS["library_caches"], "system", "Remove unprotected library caches.")
+    # Standard tier — regenerable developer/tool caches (re-download on demand).
+    # Present in balanced and max; previewed (never deleted) in safe.
+    safe_delete_action("uv_cache", SAFE_CACHE_PATHS["uv_cache"], "system", "Regenerable uv cache.", apply_allowed=applies)
+    safe_delete_action("trunk_cache", SAFE_CACHE_PATHS["trunk_cache"], "system", "Regenerable trunk cache.", apply_allowed=applies)
+    safe_delete_action("gradle_cache", SAFE_CACHE_PATHS["gradle_cache"], "system", "Regenerable Gradle cache.", apply_allowed=applies)
+    safe_delete_action("npm_cache", SAFE_CACHE_PATHS["npm_cache"], "system", "Regenerable npm cache.", apply_allowed=applies)
+    safe_delete_action("npx_cache", SAFE_CACHE_PATHS["npx_cache"], "system", "Regenerable npx cache.", apply_allowed=applies)
 
     process_summary = snapshot["process_summary"]
-    if mode in {"balanced", "max"} and process_summary["docker"]["recommended_action"] == "docker_system_prune":
+    if process_summary["docker"]["recommended_action"] == "docker_system_prune":
         actions.append(
             CleanupAction(
                 target="docker_system_prune",
@@ -1142,13 +1147,20 @@ def plan_cleanup(snapshot: Dict[str, Any], mode: str = "balanced") -> List[Clean
                 bytes_reclaimed=0,
                 reason="Prune stopped containers, dangling images, and build cache via Docker daemon.",
                 details={
-                    "apply_allowed": True,
+                    "apply_allowed": applies,
                     "inventory_counts": process_summary["docker"].get("inventory_counts", {}),
                 },
             )
         )
 
+    # Aggressive tier (max only) — broad caches with a wider blast radius.
     if mode == "max":
+        safe_delete_action(
+            "library_caches",
+            SAFE_CACHE_PATHS["library_caches"],
+            "system",
+            "Remove all unprotected ~/Library/Caches entries (aggressive; max mode only).",
+        )
         claude_state = process_summary["claude"]["state"]
         codex_state = process_summary["codex"]["state"]
         if claude_state in {"inactive", "residual_data_only"}:
@@ -1164,6 +1176,11 @@ def plan_cleanup(snapshot: Dict[str, Any], mode: str = "balanced") -> List[Clean
 
 
 def path_delete(path: Path) -> None:
+    # Remove a symlink itself rather than following it — never traverse out of
+    # the intended tree (and avoid shutil.rmtree raising on a symlinked dir).
+    if path.is_symlink():
+        path.unlink(missing_ok=True)
+        return
     if not path.exists():
         return
     if path.is_dir():
@@ -1302,8 +1319,11 @@ def build_cleanup_report(
 ) -> CleanupReport:
     storage_before = before_snapshot["host_disk_used_bytes"]
     storage_after = after_snapshot["host_disk_used_bytes"]
+    # Attribute only the bytes DreamCleanr actually acted on. The previous
+    # max(host-disk-delta, planned) could overstate the receipt when unrelated
+    # processes freed disk during the run — receipts must not inflate.
     planned_bytes = sum(action.bytes_reclaimed for action in actions)
-    storage_reclaimed = planned_bytes if dry_run else max(storage_before - storage_after, planned_bytes)
+    storage_reclaimed = planned_bytes
 
     memory_before = sum(item["rss_kb"] for item in before_snapshot["processes"]) / 1024.0
     memory_reclaimed = sum(action.bytes_reclaimed for action in actions if action.target_type == "process") / (1024.0 * 1024.0)

--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -8,6 +8,7 @@ import signal
 import subprocess
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -273,12 +274,33 @@ def du_bytes(path: Path) -> int:
         return 0
 
 
+def du_bytes_many(paths: Iterable[Path]) -> Dict[str, int]:
+    """Size many paths concurrently. du is subprocess/IO-bound, so a small thread
+    pool turns a serial sweep of large model/cache dirs into a parallel one."""
+    unique: List[Path] = []
+    seen = set()
+    for path in paths:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            unique.append(path)
+    if not unique:
+        return {}
+    with ThreadPoolExecutor(max_workers=min(8, len(unique))) as pool:
+        sizes = list(pool.map(du_bytes, unique))
+    return {str(path): size for path, size in zip(unique, sizes)}
+
+
 def gather_detector_findings(home: Optional[Path] = None) -> List[Dict[str, Any]]:
     home = home or Path.home()
-    findings: List[DetectorFinding] = []
-    for key, detector in detector_registry(home).items():
-        observed_paths: List[Dict[str, Any]] = []
-        total_bytes = 0
+    registry = detector_registry(home)
+
+    # First pass: collect existing paths (deduped per detector); size them all
+    # together in parallel so big model dirs don't serialize the scan.
+    per_detector: Dict[str, List[Tuple[str, Path]]] = {}
+    all_paths: List[Path] = []
+    for key, detector in registry.items():
+        items: List[Tuple[str, Path]] = []
         seen_paths = set()
         for label, path in detector["paths"]:
             normalized = str(path)
@@ -287,7 +309,17 @@ def gather_detector_findings(home: Optional[Path] = None) -> List[Dict[str, Any]
             seen_paths.add(normalized)
             if not path.exists():
                 continue
-            size_bytes = du_bytes(path)
+            items.append((label, path))
+            all_paths.append(path)
+        per_detector[key] = items
+    size_map = du_bytes_many(all_paths)
+
+    findings: List[DetectorFinding] = []
+    for key, detector in registry.items():
+        observed_paths: List[Dict[str, Any]] = []
+        total_bytes = 0
+        for label, path in per_detector[key]:
+            size_bytes = size_map.get(str(path), 0)
             observed_paths.append(
                 {
                     "label": label,
@@ -869,26 +901,13 @@ def attach_classification_counts(processes: List[ProcessRecord], family_summarie
 
 
 def gather_storage_records(family_summaries: Dict[str, Dict[str, Any]]) -> Tuple[List[StorageRecord], List[StorageRecord], List[StorageRecord]]:
-    records: List[StorageRecord] = []
-    protected: List[StorageRecord] = []
-    manual: List[StorageRecord] = []
+    pending: List[Tuple[str, Path, str, str, str]] = []
 
     def add_record(label: str, path: Path, family: str, classification: str, notes: str) -> None:
+        # Defer sizing — collect candidates now, du them all in parallel below.
         if not path.exists():
             return
-        record = StorageRecord(
-            label=label,
-            path=str(path),
-            family=family,
-            classification=classification,
-            size_bytes=du_bytes(path),
-            notes=notes,
-        )
-        records.append(record)
-        if classification == "PROTECTED_STATE":
-            protected.append(record)
-        elif classification == "REVIEW_VM":
-            manual.append(record)
+        pending.append((label, path, family, classification, notes))
 
     for label, path in SAFE_CACHE_PATHS.items():
         add_record(label, path, "system", "SAFE_CACHE", "Regenerable cache or developer artifact.")
@@ -921,6 +940,24 @@ def gather_storage_records(family_summaries: Dict[str, Dict[str, Any]]) -> Tuple
             classification = "SAFE_CACHE" if family_summaries["codex"]["state"] == "inactive" else "PROTECTED_STATE"
             add_record(f"codex_support_cache:{dirname}", path, "codex", classification, "Codex support cache directory.")
 
+    size_map = du_bytes_many([path for _, path, _, _, _ in pending])
+    records: List[StorageRecord] = []
+    protected: List[StorageRecord] = []
+    manual: List[StorageRecord] = []
+    for label, path, family, classification, notes in pending:
+        record = StorageRecord(
+            label=label,
+            path=str(path),
+            family=family,
+            classification=classification,
+            size_bytes=size_map.get(str(path), 0),
+            notes=notes,
+        )
+        records.append(record)
+        if classification == "PROTECTED_STATE":
+            protected.append(record)
+        elif classification == "REVIEW_VM":
+            manual.append(record)
     return records, protected, manual
 
 

--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -1548,10 +1548,24 @@ def terminate_process(pid: int) -> bool:
 
 
 def process_args(pid: int) -> Optional[str]:
-    """Current argument string for a live PID, or None if it no longer exists."""
+    """Current argument string for a live PID, or None if it no longer exists.
+
+    Distinguishes "PID gone" (ps exits 0, stdout empty) from "ps failed for
+    other reasons" (non-zero exit). When ps fails — permissions, timeout,
+    command-not-found — we raise rather than return None, because the
+    caller's interpretation of None is "process exited," which would lead
+    apply_actions() to wrongly record a 'terminated' result for a process
+    we never actually terminated (Codex P1 review on PR #30).
+    """
     result = run_command(["ps", "-p", str(pid), "-o", "args="], timeout=3)
     if not result["ok"]:
-        return None
+        # ps -p <pid> returns exit code 1 when the PID doesn't exist —
+        # that's the only "ok=False" we treat as "gone." Anything else
+        # (timeout, error message in stderr) we surface so the caller can
+        # decide not to record termination.
+        if result.get("returncode") == 1 and not result.get("stderr", "").strip():
+            return None
+        raise RuntimeError(f"ps -p {pid} failed: {result.get('stderr', '?')[:200]}")
     text = result["stdout"].strip()
     return text or None
 
@@ -1597,7 +1611,15 @@ def apply_actions(
                 pid = int(action.target)
                 # Guard against PID reuse between scan and apply: confirm the PID
                 # still belongs to the family we classified before sending a signal.
-                current_family = process_family(pid)
+                try:
+                    current_family = process_family(pid)
+                except RuntimeError as e:
+                    # ps lookup failed for a non-"process-gone" reason — don't
+                    # claim termination on what we can't observe.
+                    realized.result = "blocked"
+                    realized.reason = f"Could not verify process state via ps: {e}"
+                    applied.append(realized)
+                    continue
                 if current_family is None:
                     realized.result = "terminated"
                     realized.reason = "Process already exited before apply."
@@ -1664,18 +1686,46 @@ def build_cleanup_report(
 ) -> CleanupReport:
     storage_before = before_snapshot["host_disk_used_bytes"]
     storage_after = after_snapshot["host_disk_used_bytes"]
-    # Honestly separate disk vs RAM: caches/docker are disk; terminated processes
-    # and unloaded models are RAM. Don't conflate the two in the receipt.
-    storage_reclaimed = sum(action.bytes_reclaimed for action in actions if action.target_type in {"path", "docker"})
+    # Disk reclamation only counts actions that ACTUALLY freed disk on this
+    # filesystem. Excludes:
+    #   - blocked / failed / skipped / missing / kept / planned (didn't happen)
+    #   - trashed paths (still occupy disk under ~/.Trash until emptied)
+    # Per PR #30 review (Gemini HIGH + Codex P2 on core.py:1642/1669).
+    storage_reclaimed = sum(
+        action.bytes_reclaimed
+        for action in actions
+        if action.target_type in {"path", "docker"}
+        and action.result == "deleted"
+        and not action.details.get("trashed", False)
+    )
 
     memory_before = sum(item["rss_kb"] for item in before_snapshot["processes"]) / 1024.0
+    # RAM reclamation only counts actions that ACTUALLY unloaded RAM:
+    #   - process: result == 'terminated' (NOT planned/blocked/failed/kept)
+    #   - memory:  result == 'unloaded'    (NOT skipped/blocked)
     memory_reclaimed = sum(
-        action.bytes_reclaimed for action in actions if action.target_type in {"process", "memory"}
+        action.bytes_reclaimed
+        for action in actions
+        if (action.target_type == "process" and action.result == "terminated")
+        or (action.target_type == "memory" and action.result == "unloaded")
     ) / (1024.0 * 1024.0)
     memory_after = max(0.0, memory_before - memory_reclaimed)
 
-    processes_trimmed = sum(1 for action in actions if action.target_type == "process" and action.result in {"planned", "terminated"})
-    objects_pruned = sum(1 for action in actions if action.target_type != "process" and action.result in {"planned", "deleted"})
+    # planned counts toward "would do" stats only in dry_run; otherwise only
+    # actually-completed actions count toward trim/prune.
+    success_results_disk = {"deleted"}
+    success_results_proc = {"terminated"}
+    if dry_run:
+        success_results_disk = success_results_disk | {"planned"}
+        success_results_proc = success_results_proc | {"planned"}
+    processes_trimmed = sum(
+        1 for action in actions
+        if action.target_type == "process" and action.result in success_results_proc
+    )
+    objects_pruned = sum(
+        1 for action in actions
+        if action.target_type != "process" and action.result in success_results_disk
+    )
 
     return CleanupReport(
         run_id=before_snapshot["run_id"],

--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -200,14 +200,16 @@ def parse_size_to_bytes(text: str) -> int:
     if not raw:
         return 0
     raw = raw.replace(" ", "")
-    units = {
-        "B": 1,
-        "KB": 1024,
-        "MB": 1024 ** 2,
-        "GB": 1024 ** 3,
-        "TB": 1024 ** 4,
-    }
-    for unit, scale in units.items():
+    # Longest units first — otherwise "40GB" matches the "B" suffix and "40G"
+    # fails to parse (returning 0).
+    units = [
+        ("TB", 1024 ** 4),
+        ("GB", 1024 ** 3),
+        ("MB", 1024 ** 2),
+        ("KB", 1024),
+        ("B", 1),
+    ]
+    for unit, scale in units:
         if raw.endswith(unit):
             number = raw[: -len(unit)]
             try:
@@ -1065,6 +1067,87 @@ def list_docker_inventory() -> DockerInventory:
     return inventory
 
 
+def capture_memory_state() -> Dict[str, Any]:
+    """Honest macOS RAM breakdown via vm_stat (stdlib). Inactive/cached memory is
+    reported but explicitly NOT counted as reclaimable — the kernel reuses it."""
+    state: Dict[str, Any] = {"available": False, "total_bytes": 0}
+    sysctl = run_command(["sysctl", "-n", "hw.memsize"], timeout=3)
+    if sysctl["ok"]:
+        try:
+            state["total_bytes"] = int(sysctl["stdout"].strip())
+        except ValueError:
+            pass
+    result = run_command(["vm_stat"], timeout=3)
+    if not result["ok"]:
+        return state
+    page_size = 4096
+    pages: Dict[str, int] = {}
+    for line in result["stdout"].splitlines():
+        match = re.search(r"page size of (\d+) bytes", line)
+        if match:
+            page_size = int(match.group(1))
+            continue
+        key, _, value = line.partition(":")
+        number = value.strip().rstrip(".")
+        if number.isdigit():
+            pages[key.strip()] = int(number)
+
+    def by(key: str) -> int:
+        return pages.get(key, 0) * page_size
+
+    wired = by("Pages wired down")
+    active = by("Pages active")
+    compressed = by("Pages occupied by compressor")
+    used = wired + active + compressed
+    total = state["total_bytes"]
+    state.update(
+        {
+            "available": True,
+            "wired_bytes": wired,
+            "active_bytes": active,
+            "inactive_bytes": by("Pages inactive"),  # kernel-managed; not "wasted"
+            "compressed_bytes": compressed,
+            "free_bytes": by("Pages free") + by("Pages speculative"),
+            "used_bytes": used,
+            "pressure_pct": round(100.0 * used / total, 1) if total else 0.0,
+        }
+    )
+    return state
+
+
+def list_loaded_models() -> List[Dict[str, Any]]:
+    """Ollama models currently resident in RAM (`ollama ps`), each reclaimable
+    with `ollama stop <name>` — reversible (re-loads on next inference). Empty if
+    ollama isn't installed. This is usually the single biggest RAM line item."""
+    if not shutil.which("ollama"):
+        return []
+    result = run_command(["ollama", "ps"], timeout=4)
+    if not result["ok"]:
+        return []
+    lines = [line for line in result["stdout"].splitlines() if line.strip()]
+    if len(lines) <= 1:
+        return []
+    models: List[Dict[str, Any]] = []
+    for line in lines[1:]:  # skip header (NAME ID SIZE PROCESSOR UNTIL)
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        size_bytes = 0
+        for index, token in enumerate(parts[:-1]):
+            if re.match(r"^\d+(\.\d+)?$", token) and parts[index + 1].upper() in {"B", "KB", "MB", "GB", "TB"}:
+                size_bytes = parse_size_to_bytes(token + parts[index + 1])
+                break
+        models.append(
+            {
+                "name": parts[0],
+                "size_bytes": size_bytes,
+                "action": f"ollama stop {parts[0]}",
+                "reversible": True,
+            }
+        )
+    return models
+
+
 def capture_snapshot(mode: str = "balanced") -> Dict[str, Any]:
     started_at = now_iso()
     run_id = uuid.uuid4().hex[:12]
@@ -1091,9 +1174,13 @@ def capture_snapshot(mode: str = "balanced") -> Dict[str, Any]:
     project_signals = gather_project_signals(processes)
     detector_findings = annotate_detector_findings(gather_detector_findings(), project_signals)
     project_summary = project_activity_summary(project_signals)
+    memory_state = capture_memory_state()
+    loaded_models = list_loaded_models()
 
     return {
         "run_id": run_id,
+        "memory_state": memory_state,
+        "loaded_models": loaded_models,
         "started_at": started_at,
         "finished_at": now_iso(),
         "mode": mode,
@@ -1284,6 +1371,57 @@ def plan_cleanup(snapshot: Dict[str, Any], mode: str = "balanced") -> List[Clean
                 planned_paths.add(candidate)
 
     return actions
+
+
+def reclaim_ceiling(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    """The maximum reclaimable right now as a sum of NAMED, actionable sources —
+    never an unattributed aggregate. RAM = stale-terminable processes + loaded
+    Ollama models; disk = everything a max-mode plan would clear. Inactive/cached
+    memory is deliberately excluded (kernel-managed, not 'wasted')."""
+    ram_sources: List[Dict[str, Any]] = []
+    for proc in snapshot.get("processes", []):
+        if proc.get("classification") in {"STALE_CLI", "STALE_HELPER"}:
+            ram_sources.append(
+                {
+                    "source": f"idle {proc.get('family', 'tool')} process (pid {proc.get('pid')})",
+                    "bytes": int(proc.get("rss_kb", 0)) * 1024,
+                    "action": "terminate",
+                    "reversible": False,
+                }
+            )
+    for model in snapshot.get("loaded_models", []):
+        ram_sources.append(
+            {
+                "source": f"Ollama model '{model['name']}' resident in RAM",
+                "bytes": int(model.get("size_bytes", 0)),
+                "action": model.get("action", "ollama stop"),
+                "reversible": True,
+            }
+        )
+    # Disk from already-measured snapshot data — no second du pass, no re-plan.
+    disk_sources: List[Dict[str, Any]] = []
+    for record in snapshot.get("storage_records", []):
+        label = record.get("label", "")
+        # Skip per-basename children — the whole "library_caches" record covers them.
+        if record.get("classification") != "SAFE_CACHE" or label.startswith("library_cache:"):
+            continue
+        size = record.get("size_bytes", 0)
+        if size > 0:
+            disk_sources.append({"source": label, "bytes": size, "action": "trash/delete", "reversible": False})
+    for finding in snapshot.get("detector_findings", []):
+        reclaimable = finding.get("reclaimable_bytes", 0)
+        if reclaimable > 0 and finding.get("safety_state") != "guarded_by_active_projects":
+            disk_sources.append(
+                {"source": f"{finding.get('key')} cache", "bytes": reclaimable, "action": "trash/delete", "reversible": False}
+            )
+    ram_sources.sort(key=lambda item: item["bytes"], reverse=True)
+    disk_sources.sort(key=lambda item: item["bytes"], reverse=True)
+    return {
+        "ram_bytes": sum(item["bytes"] for item in ram_sources),
+        "disk_bytes": sum(item["bytes"] for item in disk_sources),
+        "ram_sources": ram_sources[:8],
+        "disk_sources": disk_sources[:8],
+    }
 
 
 def _trash_dir() -> Path:

--- a/dreamcleanr/core.py
+++ b/dreamcleanr/core.py
@@ -1370,6 +1370,26 @@ def plan_cleanup(snapshot: Dict[str, Any], mode: str = "balanced") -> List[Clean
                 )
                 planned_paths.add(candidate)
 
+        # Memory reclaim: unload RAM-resident Ollama models (reversible — re-loads
+        # on next inference). Aggressive tier + confirm; never deletes the model.
+        for model in snapshot.get("loaded_models", []):
+            actions.append(
+                CleanupAction(
+                    target=model["name"],
+                    target_type="memory",
+                    family="ollama",
+                    classification="LOADED_MODEL",
+                    result="planned",
+                    bytes_reclaimed=int(model.get("size_bytes", 0)),
+                    reason="Unload idle Ollama model from RAM (reversible — re-loads on next use).",
+                    details={
+                        "apply_allowed": True,
+                        "action": model.get("action", f"ollama stop {model['name']}"),
+                        "reversible": True,
+                    },
+                )
+            )
+
     return actions
 
 
@@ -1605,6 +1625,15 @@ def apply_actions(
                     realized.result = "missing"
                 if trash and realized.result == "deleted":
                     realized.details["trashed"] = True
+            elif action.target_type == "memory":
+                command = str(action.details.get("action", "")).split()
+                if not command:
+                    realized.result = "skipped"
+                else:
+                    outcome = run_command(command, timeout=10)
+                    realized.result = "unloaded" if outcome["ok"] else "blocked"
+                    if not outcome["ok"]:
+                        realized.reason = "Could not unload from RAM."
             elif action.target_type == "docker":
                 if snapshot["process_summary"]["docker"]["recommended_action"] != "docker_system_prune":
                     realized.result = "blocked"
@@ -1635,14 +1664,14 @@ def build_cleanup_report(
 ) -> CleanupReport:
     storage_before = before_snapshot["host_disk_used_bytes"]
     storage_after = after_snapshot["host_disk_used_bytes"]
-    # Attribute only the bytes DreamCleanr actually acted on. The previous
-    # max(host-disk-delta, planned) could overstate the receipt when unrelated
-    # processes freed disk during the run — receipts must not inflate.
-    planned_bytes = sum(action.bytes_reclaimed for action in actions)
-    storage_reclaimed = planned_bytes
+    # Honestly separate disk vs RAM: caches/docker are disk; terminated processes
+    # and unloaded models are RAM. Don't conflate the two in the receipt.
+    storage_reclaimed = sum(action.bytes_reclaimed for action in actions if action.target_type in {"path", "docker"})
 
     memory_before = sum(item["rss_kb"] for item in before_snapshot["processes"]) / 1024.0
-    memory_reclaimed = sum(action.bytes_reclaimed for action in actions if action.target_type == "process") / (1024.0 * 1024.0)
+    memory_reclaimed = sum(
+        action.bytes_reclaimed for action in actions if action.target_type in {"process", "memory"}
+    ) / (1024.0 * 1024.0)
     memory_after = max(0.0, memory_before - memory_reclaimed)
 
     processes_trimmed = sum(1 for action in actions if action.target_type == "process" and action.result in {"planned", "terminated"})

--- a/dreamcleanr/models.py
+++ b/dreamcleanr/models.py
@@ -78,6 +78,14 @@ class DetectorFinding(_Dictable):
     active_project_count: int = 0
     active_project_roots: List[str] = field(default_factory=list)
     observed_paths: List[Dict[str, Any]] = field(default_factory=list)
+    # Smart-reclaim metadata. reclaim_policy: "regenerable" (caches that re-create
+    # on demand) vs "model_data" (downloaded models — expensive to refetch, never
+    # auto-deleted). last_touched_days is a heuristic = days since the most recent
+    # TOP-LEVEL mtime among observed paths (not deep, not access time).
+    reclaim_policy: str = "regenerable"
+    last_touched_days: Optional[int] = None
+    reclaimable_bytes: int = 0
+    recommendation: str = ""
 
 
 @dataclass

--- a/dreamcleanr/reporting.py
+++ b/dreamcleanr/reporting.py
@@ -124,6 +124,10 @@ def build_receipt_summary(report: Dict[str, Any]) -> Dict[str, Any]:
                 "path_count": finding.get("path_count", 0),
                 "safety_state": finding.get("safety_state", "visibility_only"),
                 "active_project_count": finding.get("active_project_count", 0),
+                "reclaim_policy": finding.get("reclaim_policy", "regenerable"),
+                "reclaimable_bytes": finding.get("reclaimable_bytes", 0),
+                "last_touched_days": finding.get("last_touched_days"),
+                "recommendation": finding.get("recommendation", ""),
             }
         )
     top_storage_targets = []

--- a/dreamcleanr/scheduler.py
+++ b/dreamcleanr/scheduler.py
@@ -44,6 +44,7 @@ def write_launch_agent(
     <string>dreamcleanr</string>
     <string>clean</string>
     <string>--apply</string>
+    <string>--yes</string>
     <string>--mode</string>
     <string>{mode}</string>
     <string>--output-dir</string>

--- a/macos/DreamCleanrMenubar/Sources/App.swift
+++ b/macos/DreamCleanrMenubar/Sources/App.swift
@@ -54,11 +54,22 @@ struct MenuBarContent: View {
 
     @State private var lastScanResult: String? = nil
     @State private var isWorking: Bool = false
+    @State private var latestReport: LatestReportSummary? = nil
 
     var body: some View {
         // Status row
         Text(diskMonitor.statusText)
             .font(.system(size: 12, weight: .medium))
+
+        // Latest receipt — shows the last cleanup's actual outcome without
+        // re-running the CLI. Loaded lazily; updates on every CLI run.
+        if let r = latestReport {
+            Text(r.menuLine)
+                .font(.system(size: 11))
+            Text(r.subline)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
 
         Divider()
 
@@ -124,6 +135,9 @@ struct MenuBarContent: View {
             Text(result).font(.caption2).foregroundColor(.secondary)
         }
     }
+    .task {
+        await loadLatestReport()
+    }
 
     private func runCli(_ args: [String]) async {
         isWorking = true
@@ -131,6 +145,14 @@ struct MenuBarContent: View {
         let result = await CliRunner.shared.run(args)
         lastScanResult = result
         diskMonitor.refresh()
+        // Pick up the receipt the CLI just wrote.
+        latestReport = await LatestReportReader.shared.read()
+    }
+
+    /// Called on view appearance so the menu shows the last cleanup
+    /// outcome immediately, even before the user runs anything.
+    func loadLatestReport() async {
+        latestReport = await LatestReportReader.shared.read()
     }
 
     private func openReportsFolder() {

--- a/macos/DreamCleanrMenubar/Sources/LatestReportReader.swift
+++ b/macos/DreamCleanrMenubar/Sources/LatestReportReader.swift
@@ -1,0 +1,117 @@
+// LatestReportReader — surfaces the most-recent DreamCleanr cleanup
+// receipt in the menu bar without re-running the CLI.
+//
+// Reads ~/Library/Logs/DreamCleanr/reports/latest-summary.json (written
+// by the Python CLI on every clean / scan with --apply) and parses the
+// headline numbers: storage reclaimed, RAM reclaimed, finished_at.
+//
+// Per AGENTS.md: the macOS shell wraps the CLI and never duplicates
+// cleanup logic. This file is read-only — it consumes receipts the
+// CLI produced.
+//
+// Per issue #2 — first shipping slice (read receipts; render in menu).
+
+import Foundation
+
+/// Snapshot of the most recent DreamCleanr cleanup, parsed from disk.
+struct LatestReportSummary {
+    let runId: String
+    let finishedAt: String          // ISO 8601 from the CLI
+    let storageReclaimedBytes: Int  // disk-only — does NOT include trashed bytes
+    let memoryReclaimedMb: Double   // RAM (process termination + model unload)
+    let processesTrimmed: Int
+    let objectsPruned: Int
+    let mode: String                // safe | balanced | max
+    let dryRun: Bool
+
+    /// One-line human summary suitable for the menu.
+    var menuLine: String {
+        if dryRun {
+            return "Preview: would reclaim \(humanBytes(storageReclaimedBytes)) disk, \(formatMb(memoryReclaimedMb)) RAM"
+        }
+        return "Last clean: \(humanBytes(storageReclaimedBytes)) disk + \(formatMb(memoryReclaimedMb)) RAM"
+    }
+
+    /// Detailed second line.
+    var subline: String {
+        "\(processesTrimmed) procs · \(objectsPruned) objects · \(mode)"
+    }
+}
+
+actor LatestReportReader {
+    static let shared = LatestReportReader()
+
+    private static func summaryPath() -> URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Logs", isDirectory: true)
+            .appendingPathComponent("DreamCleanr", isDirectory: true)
+            .appendingPathComponent("reports", isDirectory: true)
+            .appendingPathComponent("latest-summary.json")
+    }
+
+    /// Read the latest cleanup summary. Returns nil if no report exists yet
+    /// or the file is malformed (CLI may have written a partial file mid-run).
+    func read() -> LatestReportSummary? {
+        let path = Self.summaryPath()
+        guard FileManager.default.fileExists(atPath: path.path),
+              let data = try? Data(contentsOf: path),
+              let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+
+        // The CLI writes both the report and a summary; the summary has
+        // pre-rolled-up numbers. Tolerate either shape — fall back to
+        // the report fields if the summary keys aren't present.
+        let storage = (raw["storage_reclaimed_bytes"] as? Int)
+            ?? (raw["report"] as? [String: Any]).flatMap { $0["storage_reclaimed_bytes"] as? Int }
+            ?? 0
+        let memMb = (raw["memory_reclaimed_estimate_mb"] as? Double)
+            ?? (raw["report"] as? [String: Any]).flatMap { $0["memory_reclaimed_estimate_mb"] as? Double }
+            ?? 0.0
+        let trimmed = (raw["processes_trimmed"] as? Int) ?? 0
+        let pruned = (raw["objects_pruned"] as? Int) ?? 0
+        let mode = (raw["mode"] as? String) ?? "balanced"
+        let dryRun = (raw["dry_run"] as? Bool) ?? false
+        let runId = (raw["run_id"] as? String) ?? "unknown"
+        let finishedAt = (raw["finished_at"] as? String) ?? ""
+
+        return LatestReportSummary(
+            runId: runId,
+            finishedAt: finishedAt,
+            storageReclaimedBytes: storage,
+            memoryReclaimedMb: memMb,
+            processesTrimmed: trimmed,
+            objectsPruned: pruned,
+            mode: mode,
+            dryRun: dryRun
+        )
+    }
+}
+
+// MARK: - Formatting helpers (kept local so the file is self-contained)
+
+/// Human-readable bytes (1.4 GB, 512 MB, 128 KB).
+func humanBytes(_ n: Int) -> String {
+    guard n > 0 else { return "0 B" }
+    let units = ["B", "KB", "MB", "GB", "TB"]
+    var v = Double(n)
+    var i = 0
+    while v >= 1024 && i < units.count - 1 {
+        v /= 1024
+        i += 1
+    }
+    if i == 0 {
+        return "\(Int(v)) \(units[i])"
+    }
+    return String(format: "%.1f %@", v, units[i])
+}
+
+/// MB formatter that drops the decimal when it's a clean integer.
+func formatMb(_ mb: Double) -> String {
+    if mb == 0 { return "0 MB" }
+    if mb.truncatingRemainder(dividingBy: 1) == 0 {
+        return "\(Int(mb)) MB"
+    }
+    return String(format: "%.1f MB", mb)
+}

--- a/macos/DreamCleanrMenubar/Tests/LatestReportReaderTests.swift
+++ b/macos/DreamCleanrMenubar/Tests/LatestReportReaderTests.swift
@@ -1,0 +1,58 @@
+// LatestReportReaderTests — verify the receipt parser handles both the
+// summary schema and the full report schema, and degrades gracefully on
+// malformed / missing files.
+
+import XCTest
+@testable import DreamCleanrMenubar
+
+final class LatestReportReaderTests: XCTestCase {
+
+    // The formatting helpers are pure functions — easiest to pin first.
+
+    func testHumanBytesFormatsTiers() {
+        XCTAssertEqual(humanBytes(0), "0 B")
+        XCTAssertEqual(humanBytes(512), "512 B")
+        XCTAssertEqual(humanBytes(1024), "1.0 KB")
+        XCTAssertEqual(humanBytes(1024 * 1024), "1.0 MB")
+        XCTAssertEqual(humanBytes(2 * 1024 * 1024 * 1024), "2.0 GB")
+    }
+
+    func testHumanBytesNegativeOrZero() {
+        XCTAssertEqual(humanBytes(0), "0 B")
+        XCTAssertEqual(humanBytes(-1), "0 B")
+    }
+
+    func testFormatMbDropsZeroDecimal() {
+        XCTAssertEqual(formatMb(0), "0 MB")
+        XCTAssertEqual(formatMb(8), "8 MB")
+        XCTAssertEqual(formatMb(8.5), "8.5 MB")
+    }
+
+    // Menu line composition — verify both summary lines render the
+    // dry-run prefix correctly.
+
+    func testMenuLineForApplyRun() {
+        let r = LatestReportSummary(
+            runId: "r1", finishedAt: "2026-05-29T05:00:00Z",
+            storageReclaimedBytes: 1024 * 1024 * 1024,
+            memoryReclaimedMb: 4096,
+            processesTrimmed: 3, objectsPruned: 12,
+            mode: "balanced", dryRun: false
+        )
+        XCTAssertEqual(r.menuLine, "Last clean: 1.0 GB disk + 4096 MB RAM")
+        XCTAssertEqual(r.subline, "3 procs · 12 objects · balanced")
+    }
+
+    func testMenuLineForDryRun() {
+        let r = LatestReportSummary(
+            runId: "r2", finishedAt: "2026-05-29T05:00:00Z",
+            storageReclaimedBytes: 500 * 1024 * 1024,
+            memoryReclaimedMb: 0,
+            processesTrimmed: 0, objectsPruned: 5,
+            mode: "balanced", dryRun: true
+        )
+        XCTAssertTrue(r.menuLine.hasPrefix("Preview: would reclaim"))
+        XCTAssertTrue(r.menuLine.contains("500.0 MB"))
+        XCTAssertTrue(r.menuLine.contains("0 MB RAM"))
+    }
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -167,18 +167,26 @@ class CliTests(unittest.TestCase):
             self.assertTrue((root / "report-team-export.csv").exists())
 
 
-    def test_clean_apply_refuses_noninteractive_without_yes(self) -> None:
+    def test_clean_apply_noninteractive_proceeds_without_prompt(self) -> None:
+        # Scripted / scheduled runs (no TTY) apply without prompting — this is
+        # what keeps an already-installed LaunchAgent working after upgrade.
         apply_mock = MagicMock(return_value=[])
+        confirm_mock = MagicMock(return_value=True)
         with TemporaryDirectory() as tmpdir:
             args = _apply_args(tmpdir, yes=False)
             with patch("dreamcleanr.cli.capture_snapshot", return_value={}), patch(
                 "dreamcleanr.cli.plan_cleanup", return_value=[_deletion_action()]
             ), patch("dreamcleanr.cli.apply_actions", apply_mock), patch(
+                "dreamcleanr.cli.build_cleanup_report", return_value=_StubReport()
+            ), patch("dreamcleanr.cli.build_receipt_summary", return_value={}), patch(
+                "dreamcleanr.cli.write_html"
+            ), patch("dreamcleanr.cli._confirm_apply", confirm_mock), patch(
                 "sys.stdin.isatty", return_value=False
             ):
                 result = command_clean(args)
-        self.assertEqual(result, 2)
-        apply_mock.assert_not_called()
+        self.assertEqual(result, 0)
+        confirm_mock.assert_not_called()
+        self.assertFalse(apply_mock.call_args.kwargs["dry_run"])
 
     def test_clean_apply_with_yes_skips_confirmation(self) -> None:
         apply_mock = MagicMock(return_value=[])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,11 +32,12 @@ def _deletion_action() -> CleanupAction:
     )
 
 
-def _apply_args(tmpdir: str, yes: bool) -> Namespace:
+def _apply_args(tmpdir: str, yes: bool, mode: str = "balanced", trash=None) -> Namespace:
     return Namespace(
-        mode="balanced",
+        mode=mode,
         apply=True,
         yes=yes,
+        trash=trash,
         output_dir=tmpdir,
         json_out=None,
         html_out=None,
@@ -204,6 +205,35 @@ class CliTests(unittest.TestCase):
         self.assertEqual(result, 0)
         confirm_mock.assert_not_called()
         self.assertFalse(apply_mock.call_args.kwargs["dry_run"])
+
+    def test_trash_defaults_on_for_max_off_for_balanced(self) -> None:
+        for mode, expected_trash in (("max", True), ("balanced", False)):
+            apply_mock = MagicMock(return_value=[])
+            with TemporaryDirectory() as tmpdir:
+                args = _apply_args(tmpdir, yes=True, mode=mode)
+                with patch("dreamcleanr.cli.capture_snapshot", return_value={}), patch(
+                    "dreamcleanr.cli.plan_cleanup", return_value=[_deletion_action()]
+                ), patch("dreamcleanr.cli.apply_actions", apply_mock), patch(
+                    "dreamcleanr.cli.build_cleanup_report", return_value=_StubReport()
+                ), patch("dreamcleanr.cli.build_receipt_summary", return_value={}), patch(
+                    "dreamcleanr.cli.write_html"
+                ):
+                    command_clean(args)
+            self.assertEqual(apply_mock.call_args.kwargs["trash"], expected_trash, f"mode={mode}")
+
+    def test_no_trash_flag_overrides_max_default(self) -> None:
+        apply_mock = MagicMock(return_value=[])
+        with TemporaryDirectory() as tmpdir:
+            args = _apply_args(tmpdir, yes=True, mode="max", trash=False)
+            with patch("dreamcleanr.cli.capture_snapshot", return_value={}), patch(
+                "dreamcleanr.cli.plan_cleanup", return_value=[_deletion_action()]
+            ), patch("dreamcleanr.cli.apply_actions", apply_mock), patch(
+                "dreamcleanr.cli.build_cleanup_report", return_value=_StubReport()
+            ), patch("dreamcleanr.cli.build_receipt_summary", return_value={}), patch(
+                "dreamcleanr.cli.write_html"
+            ):
+                command_clean(args)
+        self.assertFalse(apply_mock.call_args.kwargs["trash"])
 
     def test_clean_apply_skipped_when_report_dir_locked(self) -> None:
         import fcntl

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
 from dreamcleanr import __version__
-from dreamcleanr.cli import build_parser, command_clean, command_export
+from dreamcleanr.cli import _actions_caused_state_change, build_parser, command_clean, command_export
 from dreamcleanr.models import CleanupAction
 
 
@@ -48,6 +48,50 @@ def _apply_args(tmpdir: str, yes: bool, mode: str = "balanced", trash=None) -> N
 
 
 class CliTests(unittest.TestCase):
+    # Issue #8 — _actions_caused_state_change drives the "skip the
+    # duplicate after-snapshot" optimization. Contract: returns True iff
+    # at least one action actually mutated host state.
+
+    def test_actions_caused_state_change_true_on_deletion(self) -> None:
+        actions = [CleanupAction(target="x", target_type="path", family="f",
+                                 classification="C", result="deleted",
+                                 bytes_reclaimed=1, reason="r", details={})]
+        self.assertTrue(_actions_caused_state_change(actions))
+
+    def test_actions_caused_state_change_true_on_termination(self) -> None:
+        actions = [CleanupAction(target="123", target_type="process", family="f",
+                                 classification="C", result="terminated",
+                                 bytes_reclaimed=1, reason="r", details={})]
+        self.assertTrue(_actions_caused_state_change(actions))
+
+    def test_actions_caused_state_change_false_on_dry_run_planned(self) -> None:
+        actions = [
+            CleanupAction(target="x", target_type="path", family="f",
+                          classification="C", result="planned",
+                          bytes_reclaimed=1, reason="r", details={}),
+            CleanupAction(target="y", target_type="path", family="f",
+                          classification="C", result="kept",
+                          bytes_reclaimed=1, reason="r", details={}),
+        ]
+        self.assertFalse(_actions_caused_state_change(actions))
+
+    def test_actions_caused_state_change_false_when_all_blocked_failed(self) -> None:
+        actions = [
+            CleanupAction(target="a", target_type="path", family="f",
+                          classification="C", result="blocked",
+                          bytes_reclaimed=1, reason="r", details={}),
+            CleanupAction(target="b", target_type="path", family="f",
+                          classification="C", result="failed",
+                          bytes_reclaimed=1, reason="r", details={}),
+            CleanupAction(target="c", target_type="path", family="f",
+                          classification="C", result="missing",
+                          bytes_reclaimed=1, reason="r", details={}),
+        ]
+        self.assertFalse(_actions_caused_state_change(actions))
+
+    def test_actions_caused_state_change_false_on_empty(self) -> None:
+        self.assertFalse(_actions_caused_state_change([]))
+
     def test_version_flag_matches_package_version(self) -> None:
         parser = build_parser()
         with self.assertRaises(SystemExit) as exc:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -205,6 +205,24 @@ class CliTests(unittest.TestCase):
         confirm_mock.assert_not_called()
         self.assertFalse(apply_mock.call_args.kwargs["dry_run"])
 
+    def test_clean_apply_skipped_when_report_dir_locked(self) -> None:
+        import fcntl
+
+        apply_mock = MagicMock(return_value=[])
+        with TemporaryDirectory() as tmpdir:
+            holder = open(Path(tmpdir) / ".dreamcleanr.lock", "w")
+            fcntl.flock(holder.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            try:
+                args = _apply_args(tmpdir, yes=True)
+                with patch("dreamcleanr.cli.capture_snapshot", return_value={}), patch(
+                    "dreamcleanr.cli.plan_cleanup", return_value=[_deletion_action()]
+                ), patch("dreamcleanr.cli.apply_actions", apply_mock):
+                    result = command_clean(args)
+            finally:
+                holder.close()
+        self.assertEqual(result, 0)
+        apply_mock.assert_not_called()
+
     def test_clean_apply_decline_falls_back_to_preview(self) -> None:
         apply_mock = MagicMock(return_value=[])
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,10 +5,45 @@ import unittest
 from argparse import Namespace
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from dreamcleanr import __version__
 from dreamcleanr.cli import build_parser, command_clean, command_export
+from dreamcleanr.models import CleanupAction
+
+
+class _StubReport:
+    run_id = "runGATE"
+
+    def to_dict(self) -> dict:
+        return {"run_id": "runGATE"}
+
+
+def _deletion_action() -> CleanupAction:
+    return CleanupAction(
+        target="/tmp/dreamcleanr-test-cache",
+        target_type="path",
+        family="system",
+        classification="SAFE_CACHE",
+        result="planned",
+        bytes_reclaimed=10,
+        reason="test",
+        details={"label": "uv_cache", "apply_allowed": True},
+    )
+
+
+def _apply_args(tmpdir: str, yes: bool) -> Namespace:
+    return Namespace(
+        mode="balanced",
+        apply=True,
+        yes=yes,
+        output_dir=tmpdir,
+        json_out=None,
+        html_out=None,
+        retention_count=21,
+        open=False,
+        scope="all",
+    )
 
 
 class CliTests(unittest.TestCase):
@@ -130,6 +165,54 @@ class CliTests(unittest.TestCase):
             self.assertEqual(result, 0)
             self.assertTrue((root / "report-team-export.json").exists())
             self.assertTrue((root / "report-team-export.csv").exists())
+
+
+    def test_clean_apply_refuses_noninteractive_without_yes(self) -> None:
+        apply_mock = MagicMock(return_value=[])
+        with TemporaryDirectory() as tmpdir:
+            args = _apply_args(tmpdir, yes=False)
+            with patch("dreamcleanr.cli.capture_snapshot", return_value={}), patch(
+                "dreamcleanr.cli.plan_cleanup", return_value=[_deletion_action()]
+            ), patch("dreamcleanr.cli.apply_actions", apply_mock), patch(
+                "sys.stdin.isatty", return_value=False
+            ):
+                result = command_clean(args)
+        self.assertEqual(result, 2)
+        apply_mock.assert_not_called()
+
+    def test_clean_apply_with_yes_skips_confirmation(self) -> None:
+        apply_mock = MagicMock(return_value=[])
+        confirm_mock = MagicMock(return_value=True)
+        with TemporaryDirectory() as tmpdir:
+            args = _apply_args(tmpdir, yes=True)
+            with patch("dreamcleanr.cli.capture_snapshot", return_value={}), patch(
+                "dreamcleanr.cli.plan_cleanup", return_value=[_deletion_action()]
+            ), patch("dreamcleanr.cli.apply_actions", apply_mock), patch(
+                "dreamcleanr.cli.build_cleanup_report", return_value=_StubReport()
+            ), patch("dreamcleanr.cli.build_receipt_summary", return_value={}), patch(
+                "dreamcleanr.cli.write_html"
+            ), patch("dreamcleanr.cli._confirm_apply", confirm_mock):
+                result = command_clean(args)
+        self.assertEqual(result, 0)
+        confirm_mock.assert_not_called()
+        self.assertFalse(apply_mock.call_args.kwargs["dry_run"])
+
+    def test_clean_apply_decline_falls_back_to_preview(self) -> None:
+        apply_mock = MagicMock(return_value=[])
+        with TemporaryDirectory() as tmpdir:
+            args = _apply_args(tmpdir, yes=False)
+            with patch("dreamcleanr.cli.capture_snapshot", return_value={}), patch(
+                "dreamcleanr.cli.plan_cleanup", return_value=[_deletion_action()]
+            ), patch("dreamcleanr.cli.apply_actions", apply_mock), patch(
+                "dreamcleanr.cli.build_cleanup_report", return_value=_StubReport()
+            ), patch("dreamcleanr.cli.build_receipt_summary", return_value={}), patch(
+                "dreamcleanr.cli.write_html"
+            ), patch("sys.stdin.isatty", return_value=True), patch(
+                "dreamcleanr.cli._confirm_apply", return_value=False
+            ):
+                result = command_clean(args)
+        self.assertEqual(result, 0)
+        self.assertTrue(apply_mock.call_args.kwargs["dry_run"])
 
 
 if __name__ == "__main__":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,6 +13,7 @@ from dreamcleanr.core import (
     gather_detector_findings,
     gather_project_signals,
     parse_elapsed_to_seconds,
+    plan_cleanup,
     prune_history_files,
     summarize_family,
 )
@@ -210,6 +211,43 @@ class CoreTests(unittest.TestCase):
         self.assertEqual(annotated[0]["safety_state"], "guarded_by_active_projects")
         self.assertEqual(annotated[0]["active_project_count"], 1)
         self.assertEqual(annotated[1]["safety_state"], "visibility_only")
+
+    def test_plan_cleanup_library_sweep_is_max_only(self) -> None:
+        snapshot = {
+            "processes": [],
+            "process_summary": {
+                fam: {"state": "inactive", "recommended_action": "protect_only"}
+                for fam in ("docker", "claude", "codex")
+            },
+        }
+        with patch("dreamcleanr.core.du_bytes", return_value=0):
+            balanced = plan_cleanup(snapshot, mode="balanced")
+            aggressive = plan_cleanup(snapshot, mode="max")
+        balanced_labels = {a.details.get("label") for a in balanced}
+        max_labels = {a.details.get("label") for a in aggressive}
+        # Regenerable dev caches stay in the standard tier...
+        self.assertIn("uv_cache", balanced_labels)
+        self.assertIn("npm_cache", balanced_labels)
+        # ...but the wholesale ~/Library/Caches sweep is aggressive-only.
+        self.assertNotIn("library_caches", balanced_labels)
+        self.assertIn("library_caches", max_labels)
+
+    def test_plan_cleanup_safe_mode_is_preview_only(self) -> None:
+        snapshot = {
+            "processes": [],
+            "process_summary": {
+                fam: {"state": "inactive", "recommended_action": "protect_only"}
+                for fam in ("docker", "claude", "codex")
+            },
+        }
+        with patch("dreamcleanr.core.du_bytes", return_value=0):
+            safe = plan_cleanup(snapshot, mode="safe")
+        self.assertTrue(safe, "safe mode should still surface a preview of standard actions")
+        self.assertTrue(
+            all(not action.details.get("apply_allowed", True) for action in safe),
+            "every safe-mode action must be preview-only (apply_allowed=False)",
+        )
+        self.assertNotIn("library_caches", {a.details.get("label") for a in safe})
 
     def test_prune_history_files_keeps_most_recent_artifacts(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -212,6 +212,29 @@ class CoreTests(unittest.TestCase):
         self.assertEqual(annotated[0]["active_project_count"], 1)
         self.assertEqual(annotated[1]["safety_state"], "visibility_only")
 
+    def test_apply_blocks_terminate_when_pid_identity_changed(self) -> None:
+        snapshot = {"process_summary": {fam: {"protected_library_caches": []} for fam in ("claude", "codex")}}
+        action = CleanupAction(
+            target="4242", target_type="process", family="docker",
+            classification="STALE_CLI", result="planned", bytes_reclaimed=1024,
+            reason="stale", details={"args": "docker info", "apply_allowed": True},
+        )
+        with patch("dreamcleanr.core.process_args", return_value="/usr/bin/some-unrelated-binary --foo"):
+            applied = apply_actions(snapshot, [action], dry_run=False)
+        self.assertEqual(applied[0].result, "blocked")
+        self.assertIn("reused", applied[0].reason)
+
+    def test_apply_marks_already_exited_process_terminated(self) -> None:
+        snapshot = {"process_summary": {fam: {"protected_library_caches": []} for fam in ("claude", "codex")}}
+        action = CleanupAction(
+            target="4242", target_type="process", family="docker",
+            classification="STALE_CLI", result="planned", bytes_reclaimed=0,
+            reason="stale", details={"args": "docker info", "apply_allowed": True},
+        )
+        with patch("dreamcleanr.core.process_args", return_value=None):
+            applied = apply_actions(snapshot, [action], dry_run=False)
+        self.assertEqual(applied[0].result, "terminated")
+
     def test_plan_cleanup_library_sweep_is_max_only(self) -> None:
         snapshot = {
             "processes": [],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -455,6 +455,56 @@ class CoreTests(unittest.TestCase):
         self.assertEqual(ceiling["ram_bytes"], 1024 * 1024 + 8 * 1024 ** 3)  # stale proc + model (active excluded)
         self.assertEqual(ceiling["disk_bytes"], 2048 + 4096)  # uv + node; child/protected/guarded excluded
 
+    def test_plan_cleanup_max_unloads_loaded_models(self) -> None:
+        snapshot = {
+            "processes": [],
+            "process_summary": {fam: {"state": "inactive", "recommended_action": "protect_only"} for fam in ("docker", "claude", "codex")},
+            "loaded_models": [{"name": "llama3", "size_bytes": 8 * 1024 ** 3, "action": "ollama stop llama3"}],
+        }
+        with patch("dreamcleanr.core.du_bytes", return_value=0):
+            max_actions = plan_cleanup(snapshot, mode="max")
+            balanced = plan_cleanup(snapshot, mode="balanced")
+        mem = [a for a in max_actions if a.target_type == "memory"]
+        self.assertEqual(len(mem), 1)
+        self.assertEqual(mem[0].target, "llama3")
+        self.assertEqual(mem[0].bytes_reclaimed, 8 * 1024 ** 3)
+        self.assertTrue(mem[0].details["reversible"])
+        self.assertEqual([a for a in balanced if a.target_type == "memory"], [])  # max-only
+
+    def test_apply_unloads_model_via_command(self) -> None:
+        snapshot = {"process_summary": {fam: {"protected_library_caches": []} for fam in ("claude", "codex")}}
+        action = CleanupAction(
+            target="llama3", target_type="memory", family="ollama", classification="LOADED_MODEL",
+            result="planned", bytes_reclaimed=8 * 1024 ** 3, reason="r",
+            details={"apply_allowed": True, "action": "ollama stop llama3"},
+        )
+        captured = {}
+
+        def fake_run(cmd, timeout=5):
+            captured["cmd"] = cmd
+            return {"ok": True, "timed_out": False, "returncode": 0, "stdout": "", "stderr": ""}
+
+        with patch("dreamcleanr.core.run_command", side_effect=fake_run):
+            applied = apply_actions(snapshot, [action], dry_run=False)
+        self.assertEqual(applied[0].result, "unloaded")
+        self.assertEqual(captured["cmd"], ["ollama", "stop", "llama3"])
+
+    def test_build_cleanup_report_separates_ram_and_disk(self) -> None:
+        from dreamcleanr.core import build_cleanup_report
+
+        before = {"run_id": "r", "started_at": "s", "host_disk_used_bytes": 1000, "processes": [],
+                  "protected_items": [], "manual_review_items": [], "process_summary": {}}
+        after = {"finished_at": "f", "host_disk_used_bytes": 1000}
+        actions = [
+            CleanupAction(target="x", target_type="path", family="system", classification="SAFE_CACHE", result="deleted", bytes_reclaimed=5000, reason="r", details={}),
+            CleanupAction(target="llama3", target_type="memory", family="ollama", classification="LOADED_MODEL", result="unloaded", bytes_reclaimed=8 * 1024 ** 3, reason="r", details={}),
+            CleanupAction(target="123", target_type="process", family="docker", classification="STALE_CLI", result="terminated", bytes_reclaimed=2 * 1024 * 1024, reason="r", details={}),
+        ]
+        report = build_cleanup_report(before, after, actions, mode="max", dry_run=False)
+        self.assertEqual(report.storage_reclaimed_bytes, 5000)  # disk only — RAM not conflated
+        expected_mem_mb = round((8 * 1024 ** 3 + 2 * 1024 * 1024) / (1024 * 1024), 2)
+        self.assertEqual(report.memory_reclaimed_estimate_mb, expected_mem_mb)  # model + process
+
     def test_prune_history_files_keeps_most_recent_artifacts(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,6 +13,7 @@ from dreamcleanr.core import (
     gather_detector_findings,
     gather_project_signals,
     parse_elapsed_to_seconds,
+    parse_size_to_bytes,
     plan_cleanup,
     prune_history_files,
     summarize_family,
@@ -41,6 +42,12 @@ class CoreTests(unittest.TestCase):
         self.assertEqual(parse_elapsed_to_seconds("05:10"), 310)
         self.assertEqual(parse_elapsed_to_seconds("1:05:10"), 3910)
         self.assertEqual(parse_elapsed_to_seconds("2-01:00:00"), 176400)
+
+    def test_parse_size_to_bytes_handles_multichar_units(self) -> None:
+        self.assertEqual(parse_size_to_bytes("40 GB"), 40 * 1024 ** 3)
+        self.assertEqual(parse_size_to_bytes("5.5GB"), int(5.5 * 1024 ** 3))
+        self.assertEqual(parse_size_to_bytes("512MB"), 512 * 1024 ** 2)
+        self.assertEqual(parse_size_to_bytes("100B"), 100)
 
     def test_docker_active_backend_vs_stale_probe(self) -> None:
         processes = [
@@ -377,6 +384,76 @@ class CoreTests(unittest.TestCase):
         labels = {a.details.get("label") for a in actions}
         self.assertIn("library_caches", labels)        # wholesale sweep present
         self.assertNotIn("python:pip_cache", labels)    # overlapping path not double-planned
+
+    def test_capture_memory_state_parses_vm_stat(self) -> None:
+        from dreamcleanr.core import capture_memory_state
+
+        vm = (
+            "Mach Virtual Memory Statistics: (page size of 16384 bytes)\n"
+            "Pages free: 100.\nPages active: 200.\nPages inactive: 50.\n"
+            "Pages wired down: 300.\nPages occupied by compressor: 25.\n"
+        )
+
+        def fake_run(cmd, timeout=5):
+            if cmd[0] == "sysctl":
+                return {"ok": True, "timed_out": False, "returncode": 0, "stdout": str(16384 * 1000), "stderr": ""}
+            if cmd[0] == "vm_stat":
+                return {"ok": True, "timed_out": False, "returncode": 0, "stdout": vm, "stderr": ""}
+            return {"ok": False, "timed_out": False, "returncode": 1, "stdout": "", "stderr": ""}
+
+        with patch("dreamcleanr.core.run_command", side_effect=fake_run):
+            state = capture_memory_state()
+        self.assertTrue(state["available"])
+        self.assertEqual(state["wired_bytes"], 300 * 16384)
+        self.assertEqual(state["used_bytes"], (300 + 200 + 25) * 16384)  # inactive excluded
+        self.assertEqual(state["inactive_bytes"], 50 * 16384)  # reported, not counted as used
+
+    def test_list_loaded_models_parses_ollama_ps(self) -> None:
+        from dreamcleanr.core import list_loaded_models
+
+        out = (
+            "NAME            ID    SIZE     PROCESSOR    UNTIL\n"
+            "llama3:70b      abc   40 GB    100% GPU     4 minutes from now\n"
+            "qwen2:7b        def   5.5 GB   100% CPU     Forever\n"
+        )
+        with patch("dreamcleanr.core.shutil.which", return_value="/usr/local/bin/ollama"), patch(
+            "dreamcleanr.core.run_command",
+            return_value={"ok": True, "timed_out": False, "returncode": 0, "stdout": out, "stderr": ""},
+        ):
+            models = list_loaded_models()
+        self.assertEqual([m["name"] for m in models], ["llama3:70b", "qwen2:7b"])
+        self.assertEqual(models[0]["size_bytes"], 40 * 1024 ** 3)
+        self.assertEqual(models[0]["action"], "ollama stop llama3:70b")
+        self.assertTrue(models[0]["reversible"])
+
+    def test_list_loaded_models_empty_without_ollama(self) -> None:
+        from dreamcleanr.core import list_loaded_models
+
+        with patch("dreamcleanr.core.shutil.which", return_value=None):
+            self.assertEqual(list_loaded_models(), [])
+
+    def test_reclaim_ceiling_sums_only_named_actionable_sources(self) -> None:
+        from dreamcleanr.core import reclaim_ceiling
+
+        snapshot = {
+            "processes": [
+                {"classification": "STALE_CLI", "family": "docker", "pid": 5, "rss_kb": 1024},
+                {"classification": "ACTIVE_PRIMARY", "family": "claude", "pid": 6, "rss_kb": 9999},
+            ],
+            "loaded_models": [{"name": "llama3", "size_bytes": 8 * 1024 ** 3, "action": "ollama stop llama3"}],
+            "storage_records": [
+                {"label": "uv_cache", "classification": "SAFE_CACHE", "size_bytes": 2048},
+                {"label": "library_cache:foo", "classification": "SAFE_CACHE", "size_bytes": 999},  # child → skipped
+                {"label": "claude_home", "classification": "PROTECTED_STATE", "size_bytes": 500},  # protected → skipped
+            ],
+            "detector_findings": [
+                {"key": "node", "reclaimable_bytes": 4096, "safety_state": "visibility_only"},
+                {"key": "python", "reclaimable_bytes": 100, "safety_state": "guarded_by_active_projects"},  # guarded
+            ],
+        }
+        ceiling = reclaim_ceiling(snapshot)
+        self.assertEqual(ceiling["ram_bytes"], 1024 * 1024 + 8 * 1024 ** 3)  # stale proc + model (active excluded)
+        self.assertEqual(ceiling["disk_bytes"], 2048 + 4096)  # uv + node; child/protected/guarded excluded
 
     def test_prune_history_files_keeps_most_recent_artifacts(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -309,6 +309,75 @@ class CoreTests(unittest.TestCase):
         )
         self.assertNotIn("library_caches", {a.details.get("label") for a in safe})
 
+    def test_detector_findings_carry_reclaim_metadata(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            (home / ".cache" / "pip").mkdir(parents=True)
+            (home / ".ollama").mkdir(parents=True)
+            with patch("dreamcleanr.core.du_bytes", return_value=1024):
+                findings = gather_detector_findings(home=home)
+        by_key = {f["key"]: f for f in findings}
+        self.assertEqual(by_key["ollama"]["reclaim_policy"], "model_data")
+        self.assertEqual(by_key["ollama"]["reclaimable_bytes"], 0)  # models never auto-reclaimed
+        self.assertEqual(by_key["python"]["reclaim_policy"], "regenerable")
+        self.assertEqual(by_key["python"]["reclaimable_bytes"], 1024)  # pip_cache is regenerable
+        self.assertIsNotNone(by_key["python"]["last_touched_days"])
+
+    def _detector_snapshot(self, finding: dict) -> dict:
+        return {
+            "processes": [],
+            "process_summary": {
+                fam: {"state": "inactive", "recommended_action": "protect_only"}
+                for fam in ("docker", "claude", "codex")
+            },
+            "detector_findings": [finding],
+        }
+
+    def test_plan_cleanup_max_reclaims_stale_regenerable_detector_cache(self) -> None:
+        finding = {
+            "key": "python", "reclaim_policy": "regenerable", "safety_state": "visibility_only",
+            "last_touched_days": 30,
+            "observed_paths": [{"label": "pip_cache", "path": "/Users/x/.cache/pip", "size_bytes": 100}],
+        }
+        snapshot = self._detector_snapshot(finding)
+        with patch("dreamcleanr.core.du_bytes", return_value=100):
+            max_actions = plan_cleanup(snapshot, mode="max")
+            balanced = plan_cleanup(snapshot, mode="balanced")
+        self.assertIn("python:pip_cache", {a.details.get("label") for a in max_actions})
+        self.assertNotIn("python:pip_cache", {a.details.get("label") for a in balanced})
+
+    def test_plan_cleanup_max_skips_guarded_fresh_and_model_data(self) -> None:
+        def finding(**overrides):
+            base = {
+                "key": "python", "reclaim_policy": "regenerable", "safety_state": "visibility_only",
+                "last_touched_days": 30,
+                "observed_paths": [{"label": "pip_cache", "path": "/Users/x/.cache/pip", "size_bytes": 100}],
+            }
+            base.update(overrides)
+            return base
+
+        for case in (
+            finding(safety_state="guarded_by_active_projects"),  # active project guard
+            finding(last_touched_days=2),                        # too fresh
+            finding(reclaim_policy="model_data"),                # downloaded models
+        ):
+            with patch("dreamcleanr.core.du_bytes", return_value=100):
+                actions = plan_cleanup(self._detector_snapshot(case), mode="max")
+            self.assertNotIn("python:pip_cache", {a.details.get("label") for a in actions})
+
+    def test_plan_cleanup_max_skips_detector_path_overlapping_library_sweep(self) -> None:
+        overlapping = str(Path.home() / "Library" / "Caches" / "pip")
+        finding = {
+            "key": "python", "reclaim_policy": "regenerable", "safety_state": "visibility_only",
+            "last_touched_days": 30,
+            "observed_paths": [{"label": "pip_cache", "path": overlapping, "size_bytes": 100}],
+        }
+        with patch("dreamcleanr.core.du_bytes", return_value=100):
+            actions = plan_cleanup(self._detector_snapshot(finding), mode="max")
+        labels = {a.details.get("label") for a in actions}
+        self.assertIn("library_caches", labels)        # wholesale sweep present
+        self.assertNotIn("python:pip_cache", labels)    # overlapping path not double-planned
+
     def test_prune_history_files_keeps_most_recent_artifacts(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -505,6 +505,64 @@ class CoreTests(unittest.TestCase):
         expected_mem_mb = round((8 * 1024 ** 3 + 2 * 1024 * 1024) / (1024 * 1024), 2)
         self.assertEqual(report.memory_reclaimed_estimate_mb, expected_mem_mb)  # model + process
 
+    # Regression tests for PR #30 review (Gemini HIGH + Codex P2): the
+    # storage/memory accounting must exclude actions that didn't actually
+    # happen, AND trashed paths shouldn't count as freed disk.
+    def test_build_cleanup_report_excludes_blocked_failed_planned(self) -> None:
+        from dreamcleanr.core import build_cleanup_report
+        before = {"run_id": "r", "started_at": "s", "host_disk_used_bytes": 1000, "processes": [],
+                  "protected_items": [], "manual_review_items": [], "process_summary": {}}
+        after = {"finished_at": "f", "host_disk_used_bytes": 1000}
+        actions = [
+            # Should NOT count toward any reclaim total
+            CleanupAction(target="a", target_type="path",    family="x", classification="C", result="blocked",  bytes_reclaimed=1000, reason="r", details={}),
+            CleanupAction(target="b", target_type="path",    family="x", classification="C", result="failed",   bytes_reclaimed=2000, reason="r", details={}),
+            CleanupAction(target="c", target_type="path",    family="x", classification="C", result="missing",  bytes_reclaimed=4000, reason="r", details={}),
+            CleanupAction(target="d", target_type="path",    family="x", classification="C", result="kept",     bytes_reclaimed=8000, reason="r", details={}),
+            CleanupAction(target="e", target_type="process", family="x", classification="C", result="blocked",  bytes_reclaimed=1 * 1024 ** 2, reason="r", details={}),
+            CleanupAction(target="f", target_type="memory",  family="x", classification="C", result="blocked",  bytes_reclaimed=4 * 1024 ** 3, reason="r", details={}),
+            # SHOULD count
+            CleanupAction(target="g", target_type="path",    family="x", classification="C", result="deleted",  bytes_reclaimed=500, reason="r", details={}),
+        ]
+        report = build_cleanup_report(before, after, actions, mode="max", dry_run=False)
+        self.assertEqual(report.storage_reclaimed_bytes, 500)
+        self.assertEqual(report.memory_reclaimed_estimate_mb, 0.0)
+        self.assertEqual(report.processes_trimmed, 0)
+        self.assertEqual(report.objects_pruned, 1)
+
+    def test_build_cleanup_report_excludes_trashed_paths_from_disk(self) -> None:
+        """Trashing moves to ~/.Trash on the same volume — disk isn't freed."""
+        from dreamcleanr.core import build_cleanup_report
+        before = {"run_id": "r", "started_at": "s", "host_disk_used_bytes": 1000, "processes": [],
+                  "protected_items": [], "manual_review_items": [], "process_summary": {}}
+        after = {"finished_at": "f", "host_disk_used_bytes": 1000}
+        actions = [
+            CleanupAction(target="t", target_type="path", family="x", classification="C", result="deleted",
+                          bytes_reclaimed=12345, reason="r", details={"trashed": True}),
+            CleanupAction(target="r", target_type="path", family="x", classification="C", result="deleted",
+                          bytes_reclaimed=999, reason="r", details={}),
+        ]
+        report = build_cleanup_report(before, after, actions, mode="max", dry_run=False)
+        self.assertEqual(report.storage_reclaimed_bytes, 999)  # trashed excluded
+        self.assertEqual(report.objects_pruned, 2)  # both still count as "trimmed" objects
+
+    def test_build_cleanup_report_dry_run_counts_planned(self) -> None:
+        from dreamcleanr.core import build_cleanup_report
+        before = {"run_id": "r", "started_at": "s", "host_disk_used_bytes": 1000, "processes": [],
+                  "protected_items": [], "manual_review_items": [], "process_summary": {}}
+        after = {"finished_at": "f", "host_disk_used_bytes": 1000}
+        actions = [
+            CleanupAction(target="a", target_type="path",    family="x", classification="C", result="planned", bytes_reclaimed=100, reason="r", details={}),
+            CleanupAction(target="b", target_type="process", family="x", classification="C", result="planned", bytes_reclaimed=200, reason="r", details={}),
+        ]
+        report = build_cleanup_report(before, after, actions, mode="max", dry_run=True)
+        # planned counts toward _trimmed/_pruned (estimates), but NOT toward
+        # the byte totals — bytes only count when actions actually run.
+        self.assertEqual(report.storage_reclaimed_bytes, 0)
+        self.assertEqual(report.memory_reclaimed_estimate_mb, 0.0)
+        self.assertEqual(report.processes_trimmed, 1)
+        self.assertEqual(report.objects_pruned, 1)
+
     def test_prune_history_files_keeps_most_recent_artifacts(self) -> None:
         with TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -546,6 +546,74 @@ class CoreTests(unittest.TestCase):
         self.assertEqual(report.storage_reclaimed_bytes, 999)  # trashed excluded
         self.assertEqual(report.objects_pruned, 2)  # both still count as "trimmed" objects
 
+    # Process-fixture coverage per issue #1 — updater + crashpad +
+    # Docker-engine-only states. Pins the new families and roles.
+
+    def test_classify_generic_crashpad_handler(self) -> None:
+        # Generic crashpad helper that isn't bundled with claude/codex
+        # should land in the crashpad family, not be misattributed.
+        record = proc(901, 1, "00:30:00", 0.0, 120, "crashpad_handler",
+                      "/Library/Application Support/SomeApp/crashpad_handler --database=/tmp/x")
+        self.assertEqual(record.family, "crashpad")
+        self.assertEqual(record.role, "crashpad")
+
+    def test_classify_claude_crashpad_stays_in_claude(self) -> None:
+        # Cross-product crashpad rule must NOT steal claude's own helpers.
+        record = proc(902, 1, "00:30:00", 0.0, 120, "crashpad_handler",
+                      "/Applications/Claude.app/Contents/Frameworks/Claude Helper/crashpad_handler --database=/tmp/x")
+        self.assertEqual(record.family, "claude")
+        self.assertEqual(record.role, "crashpad")
+
+    def test_classify_sparkle_updater(self) -> None:
+        record = proc(910, 1, "00:00:30", 0.0, 80, "Sparkle",
+                      "/Library/Sparkle.app/Contents/MacOS/Sparkle --updater")
+        self.assertEqual(record.family, "updater")
+        self.assertEqual(record.role, "sparkle")
+
+    def test_classify_macos_softwareupdate(self) -> None:
+        record = proc(911, 1, "00:00:30", 0.0, 80, "softwareupdate",
+                      "/usr/sbin/softwareupdate --install --recommended")
+        self.assertEqual(record.family, "updater")
+        self.assertEqual(record.role, "macos_softwareupdate")
+
+    def test_classify_shipit_updater(self) -> None:
+        record = proc(912, 1, "00:00:30", 0.0, 80, "ShipIt",
+                      "/Applications/Foo.app/Contents/Frameworks/ShipIt /tmp/shipit-state.plist")
+        self.assertEqual(record.family, "updater")
+        self.assertEqual(record.role, "shipit")
+
+    def test_classify_microsoft_autoupdate(self) -> None:
+        record = proc(913, 1, "00:00:30", 0.0, 80, "msupdate",
+                      "/Library/Application Support/Microsoft AutoUpdate/MAU.app/Contents/MacOS/Microsoft AutoUpdate")
+        self.assertEqual(record.family, "updater")
+        self.assertEqual(record.role, "msupdate")
+
+    def test_classify_google_software_update(self) -> None:
+        record = proc(914, 1, "00:00:30", 0.0, 80, "GoogleSoftwareUpdate",
+                      "/Library/Google/GoogleSoftwareUpdate/GoogleSoftwareUpdate.bundle/Contents/Resources/GoogleSoftwareUpdateAgent.app/Contents/MacOS/GoogleSoftwareUpdateAgent")
+        self.assertEqual(record.family, "updater")
+        self.assertEqual(record.role, "google_software_update")
+
+    def test_classify_docker_engine_only_no_containers(self) -> None:
+        # Docker daemon up + no containers — still docker family, classified
+        # by role; summarize_family handles the engine-only state via the
+        # docker_inventory hint.
+        processes = [
+            proc(57788, 1, "06:00:00", 0.0, 1200, "/Applications/Do",
+                 "/Applications/Docker.app/Contents/MacOS/com.docker.backend"),
+            proc(57859, 57788, "06:00:00", 0.0, 900, "/Applications/Do",
+                 "/Applications/Docker.app/Contents/MacOS/com.docker.virtualization --disk /tmp/Docker.raw"),
+        ]
+        by_pid = {p.pid: p for p in processes}
+        # Empty inventory = engine is up but nothing to clean
+        from dreamcleanr.models import DockerInventory
+        empty_inv = DockerInventory(engine_available=True, engine_state="reachable")
+        with patch("dreamcleanr.core.run_command",
+                   return_value={"ok": True, "timed_out": False, "returncode": 0, "stdout": "{}", "stderr": ""}):
+            summary = summarize_family("docker", processes, by_pid, {99999}, docker_inventory=empty_inv)
+        # The two backend processes still classify
+        self.assertGreaterEqual(len(summary["matches"]), 2)
+
     def test_build_cleanup_report_dry_run_counts_planned(self) -> None:
         from dreamcleanr.core import build_cleanup_report
         before = {"run_id": "r", "started_at": "s", "host_disk_used_bytes": 1000, "processes": [],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -212,6 +212,20 @@ class CoreTests(unittest.TestCase):
         self.assertEqual(annotated[0]["active_project_count"], 1)
         self.assertEqual(annotated[1]["safety_state"], "visibility_only")
 
+    def test_du_bytes_many_parallel_sizes_and_dedups(self) -> None:
+        from dreamcleanr.core import du_bytes_many
+
+        calls = []
+
+        def fake(path: Path) -> int:
+            calls.append(str(path))
+            return 100
+
+        with patch("dreamcleanr.core.du_bytes", side_effect=fake):
+            result = du_bytes_many([Path("/a"), Path("/b"), Path("/a")])
+        self.assertEqual(result, {"/a": 100, "/b": 100})
+        self.assertEqual(len(calls), 2)  # deduped before sizing
+
     def test_apply_blocks_terminate_when_pid_identity_changed(self) -> None:
         snapshot = {"process_summary": {fam: {"protected_library_caches": []} for fam in ("claude", "codex")}}
         action = CleanupAction(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -212,6 +212,29 @@ class CoreTests(unittest.TestCase):
         self.assertEqual(annotated[0]["active_project_count"], 1)
         self.assertEqual(annotated[1]["safety_state"], "visibility_only")
 
+    def test_path_delete_trash_moves_instead_of_destroying(self) -> None:
+        from dreamcleanr.core import path_delete
+
+        with TemporaryDirectory() as tmpdir:
+            home = Path(tmpdir)
+            trash = home / ".Trash"
+            victim = home / "regenerable-cache"
+            victim.mkdir()
+            (victim / "blob").write_text("data", encoding="utf-8")
+            with patch("dreamcleanr.core._trash_dir", return_value=trash):
+                path_delete(victim, trash=True)
+            self.assertFalse(victim.exists())
+            self.assertTrue((trash / "regenerable-cache" / "blob").exists())  # recoverable
+
+    def test_path_delete_hard_delete_removes(self) -> None:
+        from dreamcleanr.core import path_delete
+
+        with TemporaryDirectory() as tmpdir:
+            victim = Path(tmpdir) / "cache"
+            victim.mkdir()
+            path_delete(victim, trash=False)
+            self.assertFalse(victim.exists())
+
     def test_du_bytes_many_parallel_sizes_and_dedups(self) -> None:
         from dreamcleanr.core import du_bytes_many
 

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -35,6 +35,22 @@ class VersionConsistencyTests(unittest.TestCase):
         defaults = {f.name: f.default for f in fields(CleanupReport)}
         self.assertEqual(defaults["tool_version"], dreamcleanr.__version__)
 
+    def test_cleanup_report_to_dict_covers_every_field(self) -> None:
+        # to_dict is hand-maintained; guard against adding a field and silently
+        # dropping it from receipts/exports.
+        from dataclasses import fields
+
+        from dreamcleanr.models import CleanupReport
+
+        report = CleanupReport(
+            run_id="r", started_at="", finished_at="", mode="balanced", dry_run=True,
+            storage_before_bytes=0, storage_after_bytes=0, storage_reclaimed_bytes=0,
+            memory_before_estimate_mb=0.0, memory_after_estimate_mb=0.0, memory_reclaimed_estimate_mb=0.0,
+            processes_scanned=0, processes_trimmed=0, objects_pruned=0,
+            protected_items=[], manual_review_items=[], family_summaries={}, actions=[], snapshot={},
+        )
+        self.assertEqual(set(report.to_dict().keys()), {f.name for f in fields(CleanupReport)})
+
 
 class DistributionSurfaceTests(unittest.TestCase):
     def test_mcp_integration_configs_use_local_server_entrypoint(self) -> None:


### PR DESCRIPTION
# Memory-first reclaim + re-tiered safety, faster scans, Trash net, smart caches

## Summary

A multi-part upgrade toward a memory-first dev-AI cleaner:

- **Memory-first (new primary function):** honest `vm_stat` RAM baseline (inactive/cached
  labeled kernel-managed, never counted as "wasted"), `ollama ps` loaded-model detection, and a
  **"maximum reclaimable" ceiling** surfaced as the first CLI line — *"can reclaim up to X RAM and
  Y disk right now"* — as a sum of **named, verb-bearing sources** (never an unattributed total).
- **Re-tiered safety:** the broad `~/Library/Caches` sweep moved out of the default `balanced`
  (and the unattended daily job) into `max`-only; `safe` is now a true preview; interactive
  `--apply` confirms while scripted/scheduled runs proceed (installed LaunchAgent keeps working).
- **Faster scans** (parallel `du`), **Trash safety net** (`--trash`, default-on for `max`,
  restorable via Finder), and **smart caches** (model_data never auto-deleted; regenerable caches
  reclaimed in max, active-project-guarded).
- Fixes: broken README `--dry-run` example, symlink-safe deletes, honest receipt totals, and
  `parse_size_to_bytes` ("40GB" parsed as 0).

No cleaning power was removed — it was re-characterized and made safer + reversible.

No cleaning capability was removed — it was re-tiered.

## Linked strategy (in-repo brief surrogate)

- `DREAMCLEANR_MASTER_STRATEGY.md` — "doesn't break workflows" + reversibility moat.
- `MARKET_RESEARCH_MEMO.md` — dev-safety depth as the differentiator.
- Full analysis: `audit-runs/2026-05-25/raw/mode-tiering-analysis.md`.

## Changelog (one ticket → one commit)

| Commit | Severity | Files | Tests |
| --- | --- | --- | --- |
| `feat(core): re-tier aggressive deletions to max-only; safe is preview` | Critical | `core.py`, `test_core.py` | +2 (`library_sweep_is_max_only`, `safe_mode_is_preview_only`) |
| `feat(cli): confirm before destructive --apply; require --yes when non-interactive` | Critical | `cli.py`, `scheduler.py`, `test_cli.py` | +3 (refuse / yes-skips / decline-preview) |
| `docs: fix broken --dry-run example; document cleanup tiers` | High | `README.md` | n/a |
| `fix(cli): confirm only for interactive --apply` | Critical | `cli.py`, `README.md` | (revises gate to not break installed scheduler) |
| `security(core): guard termination against PID reuse` | High | `core.py`, `test_core.py` | +2 |
| `feat(cli): exclusive run lock` | Medium | `cli.py`, `test_cli.py` | +1 |
| `test(models): assert to_dict field parity` | Medium | `test_distribution.py` | +1 |
| `perf(core): parallelize path sizing for faster scans` | High | `core.py`, `test_core.py` | +1 |
| `feat(cli): macOS Trash safety net for deletes` | High | `core.py`, `cli.py`, `README.md`, tests | +4 |
| `feat(core): smart model-cache reclaim (surface + regenerable-only)` | High | `core.py`, `models.py`, `reporting.py`, `test_core.py` | +4 |
| `feat(core): memory-first reclaim — vm_stat + loaded-model + ceiling` | High | `core.py`, `cli.py`, `test_core.py` | +5 |

## Verification

- [x] `python -m unittest discover -s tests` → **56 pass** (was 33).
- [x] Real scan on this Mac: surfaces 885 MB node regenerable cache ("safe to clear in max"); Ollama/HF model data surfaced for review, never auto-deleted; HTML report renders with new fields.
- [x] `compileall` clean.
- [x] `clean --mode balanced` previews (the corrected README command).
- [x] Interactive `--apply` prompts; non-interactive `--apply` proceeds — **no regression for the installed daily LaunchAgent** (verified this Mac's plist lacks `--yes`; the gate no longer requires it).
- [x] No new dependencies; no network calls; pure-Python stdlib only.
- [x] Did **not** run a real `--apply` deletion on the dev machine (only `safe`/dry-run).

## Open questions (human judgment)

- **Reversibility (QUAR-1):** add quarantine-with-restore? Trade-off: immediate space vs. a
  recoverable TTL window. Recommended default-on for `max` only.
- **Scheduled default tier:** keep daily job on `balanced` (now safe)? Users wanting the deep
  sweep can `schedule install --mode max`.
- **Model-cache cleanup (MODEL-1):** the biggest reclaim (HF/Ollama, 20GB+) is still
  visibility-only — green-light building it?

## Not in this PR
Native macOS app dimensions (APFS staging, Sparkle, StoreKit, sandbox/helper, …) are roadmap
build tickets — see `backlog/DEFER.md`. A faithful native audit needs a real Strategic Brief
in `docs/strategy/`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)