### PR TITLE
chore: require Python 3.11+ and add `sweep` CLI alias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "dreamcleanr"
 version = "0.3.6"
 description = "DreamCleanr: clean while you sleep with safe macOS cleanup, MCP tools, and one-page receipts."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 keywords = ["macos", "cleanup", "docker", "claude", "codex", "mcp", "developer-tools"]
 authors = [
   { name = "Jonathan Lynch" }
@@ -19,8 +19,6 @@ classifiers = [
   "Operating System :: MacOS :: MacOS X",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
-  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Topic :: System :: Systems Administration",
@@ -47,6 +45,11 @@ Support = "https://jlsport18.github.io/DreamCleanr/support.html"
 [project.scripts]
 dreamcleanr = "dreamcleanr.cli:main"
 dreamcleanr-mcp = "dreamcleanr.mcp_server:main"
+# Brand alias — the product ships as "Sweep"; the CLI help + license docs already
+# instruct users to run `sweep …` (e.g. cli.py: "sweep license activate"). Expose
+# `sweep` as a first-class entry point so those instructions actually work, while
+# keeping `dreamcleanr` for back-compat.
+sweep = "dreamcleanr.cli:main"
 
 [tool.setuptools]
 packages = ["dreamcleanr"]


### PR DESCRIPTION
Decision-independent cleanups from the Sweep GTM review (no licensing/pricing changes — those land in the licensing-keystone PR).

## Changes
- **`requires-python` 3.9 → 3.11** (3.9 is EOL Oct 2025); drop 3.9/3.10 classifiers. CI already tests 3.11/3.12 only.
- **Add `sweep` console-script** (alias of `dreamcleanr.cli:main`; `dreamcleanr` kept for back-compat). The product ships as **Sweep** and the CLI already tells users to run `sweep license activate …` (`cli.py:404`) — but no `sweep` command existed, so the instruction was dead. Now it resolves.

## Verified
Clean venv (Python 3.14): both `sweep` and `dreamcleanr` entry points work, `sweep license status` prints, **75/75 tests pass**.

## Context
Part of the perpetual-one-time GTM path (billing model confirmed: perpetual now, subscription Phase 2). The licensing keystone (Ed25519 + `check_pro()` enforcement) and the Stripe test-mode loop land in follow-up PRs — those must ship atomically (gating + secure crypto + issuance) so current free users don't lose features.